### PR TITLE
Switch to caller-rooted arguments calling convention for imported OCaml functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ocaml_frame!` is now only required to instantiate Root-variables, any interaction with the OCaml runtime will make use of an OCaml-Runtime-handle, which should be around already. The syntax also changed slightly, requiring a comma after the OCaml-Runtime-handle parameter.
 - `OCamlRoot` has been renamed to `OCamlRawRoot`.
 - Rust functions that are exported to OCaml must now declare at least one argument.
-- Functions that are exported to OCaml now follow a caller-save convention. These functions now receive `&OCamlRef<T>`  arguments.
-- Functions that are imported from OCaml now follow a caller-save convention. These functions  now receive `&OCamlRef<T>`  arguments.
+- Functions that are exported to OCaml now follow a caller-save convention. These functions now receive `OCamlRef<T>`  arguments.
+- Functions that are imported from OCaml now follow a caller-save convention. These functions  now receive `OCamlRef<T>`  arguments.
 - Calls to OCaml functions don't return `Result` anymore, and instead panic on unexpected exceptions.
 - `to_rust()` method is now implemented directly into `OCaml<T>`, the `ToRust` trait is not required anymore.
 - `keep_raw()` method in root variables is now `unsafe` and returns an `OCamlRef<T>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OCamlRuntime::releasing_runtime(&mut self, f: FnOnce() -> T)` releases the OCaml runtime, calls `f`, and then re-acquires the OCaml runtime. Maybe more complicated patterns should be supported, but for now I haven't given this much thought.
 - Support for unpacking OCaml polymorphic variants into Rust values.
 - Added `to_rust(cr: &OCamlRuntime)` method to `OCamlRooted<T>` values.
+- `OCamlRooted::unit()` method to obtain a static OCaml unit value that is rooted.
+- `OCamlRooted::none()` method to obtain a static OCaml `None` value that is rooted.
 
 ### Changed
 
@@ -21,9 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ocaml_frame!` is now only required to instantiate Root-variables, any interaction with the OCaml runtime will make use of an OCaml-Runtime-handle, which should be around already. The syntax also changed slightly, requiring a comma after the OCaml-Runtime-handle parameter.
 - `OCamlRef` has been renamed to `OCamlRooted`.
 - Rust functions that are exported to OCaml must now declare at least one argument.
-- Functions that are exported to OCaml now follow a caller-save convention. These functions now receive `OCamlRooted<T>`  parameters.
+- Functions that are exported to OCaml now follow a caller-save convention. These functions now receive `&OCamlRooted<T>`  arguments.
+- Functions that are imported from OCaml now follow a caller-save convention. These functions  now receive `&OCamlRooted<T>`  arguments.
+- Calls to OCaml functions don't return `Result` anymore, and instead panic on unexpected exceptions.
 - `to_rust()` method is now implemented directly into `OCaml<T>`, the `ToRust` trait is not required anymore.
 - `keep_raw()` method in root variables is now `unsafe` and returns an `OCamlRooted<T>`.
+- `OCaml<T>::as_i64()` -> `to_i64()`.
+- `OCaml<T>::as_bool()` -> `to_bool()`.
 
 ### Deprecated
 
@@ -31,8 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed `ToRust` trait.
-- Removed `OCamlRawRooted` type.
+- `ToRust` trait.
+- `OCamlRawRooted` type.
+- `ocaml_call!` macro.
+- `ocaml_alloc!` macro.
+- `OCamlAllocToken` type.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OCamlRuntime::releasing_runtime(&mut self, f: FnOnce() -> T)` releases the OCaml runtime, calls `f`, and then re-acquires the OCaml runtime. Maybe more complicated patterns should be supported, but for now I haven't given this much thought.
 - Support for unpacking OCaml polymorphic variants into Rust values.
 - `to_rust(cr: &OCamlRuntime)` method to `OCamlRef<T>` values.
-- `as_value_ref(&self) -> OCamlRef<T>` method to obtain roots for immediate values without performing actual rooting.
-- `OCamlRef::unit()` method to obtain a static ref to an OCaml unit value.
-- `OCamlRef::none()` method to obtain a static ref to an OCaml `None` value.
+- `OCaml::unit()` method to obtain an OCaml unit value.
+- `OCaml::none()` method to obtain an OCaml `None` value.
+- Support for tuple-structs in struct/record mapping macros.
+- `OCaml::as_ref(&self) -> OCamlRef<T>` method. Useful for immediate OCaml values (ints, unit, None, booleans) to convert them into `OCamlRef`s without the need for rooting.
+- `Deref` implementation to get an `OCamlRef<T>` from an `OCaml<T>`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `OCamlRuntime::releasing_runtime(&mut self, f: FnOnce() -> T)` releases the OCaml runtime, calls `f`, and then re-acquires the OCaml runtime. Maybe more complicated patterns should be supported, but for now I haven't given this much thought.
 - Support for unpacking OCaml polymorphic variants into Rust values.
-- Added `to_rust(cr: &OCamlRuntime)` method to `OCamlRoot<T>` values.
+- `to_rust(cr: &OCamlRuntime)` method to `OCamlRoot<T>` values.
+- `as_root(&self) -> OCamlRoot<T>` method to obtain roots for immediate values without performing actual rooting.
 - `OCamlRoot::unit()` method to obtain a static root with an OCaml unit value.
 - `OCamlRoot::none()` method to obtain a static root with an OCaml `None` value.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `OCamlRuntime::releasing_runtime(&mut self, f: FnOnce() -> T)` releases the OCaml runtime, calls `f`, and then re-acquires the OCaml runtime. Maybe more complicated patterns should be supported, but for now I haven't given this much thought.
 - Support for unpacking OCaml polymorphic variants into Rust values.
-- Added `to_rust(cr: &OCamlRuntime)` method to `OCamlRooted<T>` values.
-- `OCamlRooted::unit()` method to obtain a static OCaml unit value that is rooted.
-- `OCamlRooted::none()` method to obtain a static OCaml `None` value that is rooted.
+- Added `to_rust(cr: &OCamlRuntime)` method to `OCamlRoot<T>` values.
+- `OCamlRoot::unit()` method to obtain a static root with an OCaml unit value.
+- `OCamlRoot::none()` method to obtain a static root with an OCaml `None` value.
 
 ### Changed
 
@@ -21,13 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exported functions don't implicitly open an `ocaml_frame!` anymore, but instead receive an OCaml-runtime-handle as their first argument.
 - `ocaml_frame!` doesn't create a GC-handle anymore, but instead takes as input an OCaml-Runtime-handle, and uses it to instantiate a new frame and list of Root-variables through an immutable borrow.
 - `ocaml_frame!` is now only required to instantiate Root-variables, any interaction with the OCaml runtime will make use of an OCaml-Runtime-handle, which should be around already. The syntax also changed slightly, requiring a comma after the OCaml-Runtime-handle parameter.
-- `OCamlRef` has been renamed to `OCamlRooted`.
+- `OCamlRoot` has been renamed to `OCamlRawRoot`.
+- `OCamlRef` has been renamed to `OCamlRoot`.
 - Rust functions that are exported to OCaml must now declare at least one argument.
-- Functions that are exported to OCaml now follow a caller-save convention. These functions now receive `&OCamlRooted<T>`  arguments.
-- Functions that are imported from OCaml now follow a caller-save convention. These functions  now receive `&OCamlRooted<T>`  arguments.
+- Functions that are exported to OCaml now follow a caller-save convention. These functions now receive `&OCamlRoot<T>`  arguments.
+- Functions that are imported from OCaml now follow a caller-save convention. These functions  now receive `&OCamlRoot<T>`  arguments.
 - Calls to OCaml functions don't return `Result` anymore, and instead panic on unexpected exceptions.
 - `to_rust()` method is now implemented directly into `OCaml<T>`, the `ToRust` trait is not required anymore.
-- `keep_raw()` method in root variables is now `unsafe` and returns an `OCamlRooted<T>`.
+- `keep_raw()` method in root variables is now `unsafe` and returns an `OCamlRoot<T>`.
 - `OCaml<T>::as_i64()` -> `to_i64()`.
 - `OCaml<T>::as_bool()` -> `to_bool()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `OCamlRuntime::releasing_runtime(&mut self, f: FnOnce() -> T)` releases the OCaml runtime, calls `f`, and then re-acquires the OCaml runtime. Maybe more complicated patterns should be supported, but for now I haven't given this much thought.
 - Support for unpacking OCaml polymorphic variants into Rust values.
-- `to_rust(cr: &OCamlRuntime)` method to `OCamlRoot<T>` values.
-- `as_root(&self) -> OCamlRoot<T>` method to obtain roots for immediate values without performing actual rooting.
-- `OCamlRoot::unit()` method to obtain a static root with an OCaml unit value.
-- `OCamlRoot::none()` method to obtain a static root with an OCaml `None` value.
+- `to_rust(cr: &OCamlRuntime)` method to `OCamlRef<T>` values.
+- `as_value_ref(&self) -> OCamlRef<T>` method to obtain roots for immediate values without performing actual rooting.
+- `OCamlRef::unit()` method to obtain a static ref to an OCaml unit value.
+- `OCamlRef::none()` method to obtain a static ref to an OCaml `None` value.
 
 ### Changed
 
@@ -23,13 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ocaml_frame!` doesn't create a GC-handle anymore, but instead takes as input an OCaml-Runtime-handle, and uses it to instantiate a new frame and list of Root-variables through an immutable borrow.
 - `ocaml_frame!` is now only required to instantiate Root-variables, any interaction with the OCaml runtime will make use of an OCaml-Runtime-handle, which should be around already. The syntax also changed slightly, requiring a comma after the OCaml-Runtime-handle parameter.
 - `OCamlRoot` has been renamed to `OCamlRawRoot`.
-- `OCamlRef` has been renamed to `OCamlRoot`.
 - Rust functions that are exported to OCaml must now declare at least one argument.
-- Functions that are exported to OCaml now follow a caller-save convention. These functions now receive `&OCamlRoot<T>`  arguments.
-- Functions that are imported from OCaml now follow a caller-save convention. These functions  now receive `&OCamlRoot<T>`  arguments.
+- Functions that are exported to OCaml now follow a caller-save convention. These functions now receive `&OCamlRef<T>`  arguments.
+- Functions that are imported from OCaml now follow a caller-save convention. These functions  now receive `&OCamlRef<T>`  arguments.
 - Calls to OCaml functions don't return `Result` anymore, and instead panic on unexpected exceptions.
 - `to_rust()` method is now implemented directly into `OCaml<T>`, the `ToRust` trait is not required anymore.
-- `keep_raw()` method in root variables is now `unsafe` and returns an `OCamlRoot<T>`.
+- `keep_raw()` method in root variables is now `unsafe` and returns an `OCamlRef<T>`.
 - `OCaml<T>::as_i64()` -> `to_i64()`.
 - `OCaml<T>::as_bool()` -> `to_bool()`.
 
@@ -44,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ocaml_call!` macro.
 - `ocaml_alloc!` macro.
 - `OCamlAllocToken` type.
+- `OCamlRef::set` method (use `OCamlRawRoot::keep` instead).
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ features = [ "docs-rs" ]
 
 [dependencies]
 ocaml-sys = "0.18.1"
+static_assertions = "1.1.0"
 
 [features]
 docs-rs = ["ocaml-sys/docs-rs"]

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ ocaml! {
 
 // ...
 
-let ocaml_string = &to_ocaml!(cr, "hello OCaml!", root_var);
+let ocaml_string = to_ocaml!(cr, "hello OCaml!", root_var);
 ocaml_print_endline(cr, ocaml_string);
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 _Zinc-iron alloy coating is used in parts that need very good corrosion protection._
 
+**API IS CONSIDERED UNSTABLE AT THE MOMENT AND IS LIKELY TO CHANGE IN THE FUTURE**
+
 [ocaml-interop](https://github.com/simplestaking/ocaml-interop) is an OCaml<->Rust FFI with an emphasis on safety inspired by [caml-oxide](https://github.com/stedolan/caml-oxide) and [ocaml-rs](https://github.com/zshipko/ocaml-rs).
 
 Read the full documentation [here](https://docs.rs/ocaml-interop/).

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ ocaml! {
 
 // ...
 
-let ocaml_string = to_ocaml!(cr, "hello OCaml!");
-ocaml_call!(ocaml_print_endline(cr, ocaml_string)).unwrap();
+let ocaml_string = &to_ocaml!(cr, "hello OCaml!", root_var);
+ocaml_print_endline(cr, ocaml_string);
 ```
 
 ### Call Rust functions from OCaml

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Report issues on [Github](https://github.com/simplestaking/ocaml-interop/issues)
 
 ocaml-interop, just like [caml-oxide](https://github.com/stedolan/caml-oxide), encodes the invariants of OCaml's garbage collector into the rules of Rust's borrow checker. Any violation of these invariants results in a compilation error produced by Rust's borrow checker.
 
-This requires that the user is explicit about delimiting blocks that interact with the OCaml runtime, and that calls into the OCaml runtime are done only inside these blocks, and wrapped by a few special macros.
-
 ## A quick taste
 
 ### Convert between plain OCaml and Rust values

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -1,13 +1,12 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use crate::{OCamlRooted, OCamlRuntime, memory::OCamlAllocResult};
+use crate::{OCamlRooted, OCamlRuntime};
 use crate::mlvalues::tag;
 use crate::mlvalues::{extract_exception, is_exception_result, tag_val, RawOCaml};
 use crate::value::OCaml;
 use crate::{
     error::{OCamlError, OCamlException},
-    OCamlAllocToken,
 };
 use ocaml_sys::{
     caml_callback2_exn, caml_callback3_exn, caml_callbackN_exn, caml_callback_exn, caml_named_value,
@@ -37,28 +36,25 @@ fn get_named(name: &str) -> Option<*const RawOCaml> {
     }
 }
 
-/// The result of calls to OCaml functions. Can be a value or an error.
-pub type OCamlResult<T> = Result<OCamlAllocResult<T>, OCamlError>;
-
 /// OCaml function that accepts one argument.
-pub type OCamlFn1<A, Ret> = unsafe fn(OCamlAllocToken, OCaml<A>) -> OCamlResult<Ret>;
+pub type OCamlFn1<'a, A, Ret> = unsafe fn(&'a mut OCamlRuntime, OCaml<A>) -> OCaml<'a, Ret>;
 /// OCaml function that accepts two arguments.
-pub type OCamlFn2<A, B, Ret> = unsafe fn(OCamlAllocToken, OCaml<A>, OCaml<B>) -> OCamlResult<Ret>;
+pub type OCamlFn2<'a, A, B, Ret> = unsafe fn(&'a mut OCamlRuntime, OCaml<A>, OCaml<B>) -> OCaml<'a, Ret>;
 /// OCaml function that accepts three arguments.
-pub type OCamlFn3<A, B, C, Ret> =
-    unsafe fn(OCamlAllocToken, OCaml<A>, OCaml<B>, OCaml<C>) -> OCamlResult<Ret>;
+pub type OCamlFn3<'a, A, B, C, Ret> =
+    unsafe fn(&'a mut OCamlRuntime, OCaml<A>, OCaml<B>, OCaml<C>) -> OCaml<'a, Ret>;
 /// OCaml function that accepts four arguments.
-pub type OCamlFn4<A, B, C, D, Ret> =
-    unsafe fn(OCamlAllocToken, OCaml<A>, OCaml<B>, OCaml<C>, OCaml<D>) -> OCamlResult<Ret>;
+pub type OCamlFn4<'a, A, B, C, D, Ret> =
+    unsafe fn(&'a mut OCamlRuntime, OCaml<A>, OCaml<B>, OCaml<C>, OCaml<D>) -> OCaml<'a, Ret>;
 /// OCaml function that accepts five arguments.
-pub type OCamlFn5<A, B, C, D, E, Ret> = unsafe fn(
-    OCamlAllocToken,
+pub type OCamlFn5<'a, A, B, C, D, E, Ret> = unsafe fn(
+    &'a mut OCamlRuntime,
     OCaml<A>,
     OCaml<B>,
     OCaml<C>,
     OCaml<D>,
     OCaml<E>,
-) -> OCamlResult<Ret>;
+) -> OCaml<'a, Ret>;
 
 impl OCamlClosure {
     pub fn named(name: &str) -> Option<OCamlClosure> {

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -5,7 +5,7 @@ use crate::error::OCamlException;
 use crate::mlvalues::tag;
 use crate::mlvalues::{extract_exception, is_exception_result, tag_val, RawOCaml};
 use crate::value::OCaml;
-use crate::{OCamlRoot, OCamlRuntime};
+use crate::{OCamlRef, OCamlRuntime};
 use ocaml_sys::{
     caml_callback2_exn, caml_callback3_exn, caml_callbackN_exn, caml_callback_exn, caml_named_value,
 };
@@ -31,7 +31,7 @@ impl OCamlClosure {
         }
     }
 
-    pub fn call<'a, T, R>(&self, cr: &'a mut OCamlRuntime, arg: &OCamlRoot<T>) -> OCaml<'a, R> {
+    pub fn call<'a, T, R>(&self, cr: &'a mut OCamlRuntime, arg: &OCamlRef<T>) -> OCaml<'a, R> {
         let result = unsafe { caml_callback_exn(*self.0, arg.get_raw()) };
         self.handle_call_result(cr, result)
     }
@@ -39,8 +39,8 @@ impl OCamlClosure {
     pub fn call2<'a, T, U, R>(
         &self,
         cr: &'a mut OCamlRuntime,
-        arg1: &OCamlRoot<T>,
-        arg2: &OCamlRoot<U>,
+        arg1: &OCamlRef<T>,
+        arg2: &OCamlRef<U>,
     ) -> OCaml<'a, R> {
         let result = unsafe { caml_callback2_exn(*self.0, arg1.get_raw(), arg2.get_raw()) };
         self.handle_call_result(cr, result)
@@ -49,9 +49,9 @@ impl OCamlClosure {
     pub fn call3<'a, T, U, V, R>(
         &self,
         cr: &'a mut OCamlRuntime,
-        arg1: &OCamlRoot<T>,
-        arg2: &OCamlRoot<U>,
-        arg3: &OCamlRoot<V>,
+        arg1: &OCamlRef<T>,
+        arg2: &OCamlRef<U>,
+        arg3: &OCamlRef<V>,
     ) -> OCaml<'a, R> {
         let result =
             unsafe { caml_callback3_exn(*self.0, arg1.get_raw(), arg2.get_raw(), arg3.get_raw()) };

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -31,7 +31,7 @@ impl OCamlClosure {
         }
     }
 
-    pub fn call<'a, T, R>(&self, cr: &'a mut OCamlRuntime, arg: &OCamlRef<T>) -> OCaml<'a, R> {
+    pub fn call<'a, T, R>(&self, cr: &'a mut OCamlRuntime, arg: OCamlRef<T>) -> OCaml<'a, R> {
         let result = unsafe { caml_callback_exn(*self.0, arg.get_raw()) };
         self.handle_call_result(cr, result)
     }
@@ -39,8 +39,8 @@ impl OCamlClosure {
     pub fn call2<'a, T, U, R>(
         &self,
         cr: &'a mut OCamlRuntime,
-        arg1: &OCamlRef<T>,
-        arg2: &OCamlRef<U>,
+        arg1: OCamlRef<T>,
+        arg2: OCamlRef<U>,
     ) -> OCaml<'a, R> {
         let result = unsafe { caml_callback2_exn(*self.0, arg1.get_raw(), arg2.get_raw()) };
         self.handle_call_result(cr, result)
@@ -49,9 +49,9 @@ impl OCamlClosure {
     pub fn call3<'a, T, U, V, R>(
         &self,
         cr: &'a mut OCamlRuntime,
-        arg1: &OCamlRef<T>,
-        arg2: &OCamlRef<U>,
-        arg3: &OCamlRef<V>,
+        arg1: OCamlRef<T>,
+        arg2: OCamlRef<U>,
+        arg3: OCamlRef<V>,
     ) -> OCaml<'a, R> {
         let result =
             unsafe { caml_callback3_exn(*self.0, arg1.get_raw(), arg2.get_raw(), arg3.get_raw()) };

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -5,7 +5,7 @@ use crate::error::OCamlException;
 use crate::mlvalues::tag;
 use crate::mlvalues::{extract_exception, is_exception_result, tag_val, RawOCaml};
 use crate::value::OCaml;
-use crate::{OCamlRooted, OCamlRuntime};
+use crate::{OCamlRoot, OCamlRuntime};
 use ocaml_sys::{
     caml_callback2_exn, caml_callback3_exn, caml_callbackN_exn, caml_callback_exn, caml_named_value,
 };
@@ -60,7 +60,7 @@ impl OCamlClosure {
         get_named(name).map(OCamlClosure)
     }
 
-    pub fn call<'a, T, R>(&self, cr: &'a mut OCamlRuntime, arg: &OCamlRooted<T>) -> OCaml<'a, R> {
+    pub fn call<'a, T, R>(&self, cr: &'a mut OCamlRuntime, arg: &OCamlRoot<T>) -> OCaml<'a, R> {
         let result = unsafe { caml_callback_exn(*self.0, arg.get_raw()) };
         self.handle_call_result(cr, result)
     }
@@ -68,8 +68,8 @@ impl OCamlClosure {
     pub fn call2<'a, T, U, R>(
         &self,
         cr: &'a mut OCamlRuntime,
-        arg1: &OCamlRooted<T>,
-        arg2: &OCamlRooted<U>,
+        arg1: &OCamlRoot<T>,
+        arg2: &OCamlRoot<U>,
     ) -> OCaml<'a, R> {
         let result = unsafe { caml_callback2_exn(*self.0, arg1.get_raw(), arg2.get_raw()) };
         self.handle_call_result(cr, result)
@@ -78,9 +78,9 @@ impl OCamlClosure {
     pub fn call3<'a, T, U, V, R>(
         &self,
         cr: &'a mut OCamlRuntime,
-        arg1: &OCamlRooted<T>,
-        arg2: &OCamlRooted<U>,
-        arg3: &OCamlRooted<V>,
+        arg1: &OCamlRoot<T>,
+        arg2: &OCamlRoot<U>,
+        arg3: &OCamlRoot<V>,
     ) -> OCaml<'a, R> {
         let result =
             unsafe { caml_callback3_exn(*self.0, arg1.get_raw(), arg2.get_raw(), arg3.get_raw()) };

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -71,8 +71,8 @@ impl OCamlClosure {
         result: RawOCaml,
     ) -> OCaml<'a, R> {
         if is_exception_result(result) {
-            let ex = OCamlException::of(extract_exception(result));
-            panic!("OCaml exception: {:?}", ex)
+            let ex = unsafe { OCamlException::of(extract_exception(result)) };
+            panic!("OCaml exception, message: {:?}", ex.message())
         } else {
             unsafe { OCaml::new(cr, result) }
         }

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -80,22 +80,27 @@ impl OCamlClosure {
 }
 
 /// OCaml function that accepts one argument.
-pub type OCamlFn1<'a, A, Ret> = unsafe fn(&'a mut OCamlRuntime, OCaml<A>) -> OCaml<'a, Ret>;
+pub type OCamlFn1<'a, A, Ret> = unsafe fn(&'a mut OCamlRuntime, OCamlRef<A>) -> OCaml<'a, Ret>;
 /// OCaml function that accepts two arguments.
 pub type OCamlFn2<'a, A, B, Ret> =
-    unsafe fn(&'a mut OCamlRuntime, OCaml<A>, OCaml<B>) -> OCaml<'a, Ret>;
+    unsafe fn(&'a mut OCamlRuntime, OCamlRef<A>, OCamlRef<B>) -> OCaml<'a, Ret>;
 /// OCaml function that accepts three arguments.
 pub type OCamlFn3<'a, A, B, C, Ret> =
-    unsafe fn(&'a mut OCamlRuntime, OCaml<A>, OCaml<B>, OCaml<C>) -> OCaml<'a, Ret>;
+    unsafe fn(&'a mut OCamlRuntime, OCamlRef<A>, OCamlRef<B>, OCamlRef<C>) -> OCaml<'a, Ret>;
 /// OCaml function that accepts four arguments.
-pub type OCamlFn4<'a, A, B, C, D, Ret> =
-    unsafe fn(&'a mut OCamlRuntime, OCaml<A>, OCaml<B>, OCaml<C>, OCaml<D>) -> OCaml<'a, Ret>;
+pub type OCamlFn4<'a, A, B, C, D, Ret> = unsafe fn(
+    &'a mut OCamlRuntime,
+    OCamlRef<A>,
+    OCamlRef<B>,
+    OCamlRef<C>,
+    OCamlRef<D>,
+) -> OCaml<'a, Ret>;
 /// OCaml function that accepts five arguments.
 pub type OCamlFn5<'a, A, B, C, D, E, Ret> = unsafe fn(
     &'a mut OCamlRuntime,
-    OCaml<A>,
-    OCaml<B>,
-    OCaml<C>,
-    OCaml<D>,
-    OCaml<E>,
+    OCamlRef<A>,
+    OCamlRef<B>,
+    OCamlRef<C>,
+    OCamlRef<D>,
+    OCamlRef<E>,
 ) -> OCaml<'a, Ret>;

--- a/src/compile_fail_tests.rs
+++ b/src/compile_fail_tests.rs
@@ -51,8 +51,6 @@ pub struct OCamlRootEscapeFailureCheck;
 // error[E0597]: `ocaml_n` does not live long enough
 /// ```compile_fail
 /// # use ocaml_interop::*;
-/// # ocaml! { pub fn ocaml_function(arg1: String) -> String; }
-/// # let cr = &mut OCamlRuntime::init();
 /// let escaped = {
 ///     let ocaml_n: OCaml<'static, OCamlInt> = unsafe { OCaml::of_i64_unchecked(10) };
 ///     ocaml_n.as_value_ref()
@@ -60,3 +58,17 @@ pub struct OCamlRootEscapeFailureCheck;
 /// # ()
 /// ```
 pub struct OCamlImmediateRootEscapeFailureCheck;
+
+// Checks that OCamlRef values made from non-immediate OCaml values cannot be used
+// as if they were references to rooted values.
+// Must fail with:
+// error[E0499]: cannot borrow `*cr` as mutable more than once at a time
+/// ```compile_fail
+/// # use ocaml_interop::*;
+/// # ocaml! { fn ocaml_function(arg1: String) -> String; }
+/// # fn test(cr: &'static mut OCamlRuntime) {
+/// let arg1: OCaml<String> = to_ocaml!(cr, "test");
+/// let _ = ocaml_function(cr, &arg1);
+/// }
+/// ```
+pub struct NoStaticDerefsForNonImmediates;

--- a/src/compile_fail_tests.rs
+++ b/src/compile_fail_tests.rs
@@ -10,13 +10,13 @@
 /// ocaml_frame!(cr, (root), {
 /// let arg1: OCaml<String> = "test".to_owned().to_ocaml(cr);
 /// let arg2: OCaml<String> = "test".to_owned().to_ocaml(cr);
-/// let arg1_rooted = root.keep(arg1);
+/// let arg1_root = root.keep(arg1);
 /// # ()
 /// });
 /// ```
 pub struct LivenessFailureCheck;
 
-// Check that OCamlRoot values cannot escape the frame that created them.
+// Check that OCamlRawRoot values cannot escape the frame that created them.
 // Must fail with:
 // error[E0716]: temporary value dropped while borrowed
 /// ```compile_fail
@@ -27,9 +27,9 @@ pub struct LivenessFailureCheck;
 ///     rootvar
 /// });
 /// # ()
-pub struct OCamlRootEscapeFailureCheck;
+pub struct OCamlRawRootEscapeFailureCheck;
 
-// Check that OCamlRooted values cannot escape the frame that created the associated root.
+// Check that OCamlRoot values cannot escape the frame that created the associated root.
 // Must fail with:
 // error[E0716]: temporary value dropped while borrowed
 /// ```compile_fail
@@ -38,8 +38,8 @@ pub struct OCamlRootEscapeFailureCheck;
 /// # let cr = &mut OCamlRuntime::init();
 /// let escaped = ocaml_frame!(cr, (rootvar), {
 ///     let arg1: OCaml<String> = "test".to_owned().to_ocaml(cr);
-///     let arg1_rooted = rootvar.keep(arg1);
-///     arg1_rooted
+///     let arg1_root = rootvar.keep(arg1);
+///     arg1_root
 /// });
 /// # ()
-pub struct OCamlRootedEscapeFailureCheck;
+pub struct OCamlRootEscapeFailureCheck;

--- a/src/compile_fail_tests.rs
+++ b/src/compile_fail_tests.rs
@@ -30,7 +30,7 @@ pub struct LivenessFailureCheck;
 /// ```
 pub struct OCamlRawRootEscapeFailureCheck;
 
-// Check that OCamlRoot values cannot escape the frame that created the associated root.
+// Check that OCamlRef values cannot escape the frame that created the associated root.
 // Must fail with:
 // error[E0716]: temporary value dropped while borrowed
 /// ```compile_fail
@@ -55,7 +55,7 @@ pub struct OCamlRootEscapeFailureCheck;
 /// # let cr = &mut OCamlRuntime::init();
 /// let escaped = {
 ///     let ocaml_n: OCaml<'static, OCamlInt> = unsafe { OCaml::of_i64_unchecked(10) };
-///     ocaml_n.as_root()
+///     ocaml_n.as_value_ref()
 /// };
 /// # ()
 /// ```

--- a/src/compile_fail_tests.rs
+++ b/src/compile_fail_tests.rs
@@ -27,6 +27,7 @@ pub struct LivenessFailureCheck;
 ///     rootvar
 /// });
 /// # ()
+/// ```
 pub struct OCamlRawRootEscapeFailureCheck;
 
 // Check that OCamlRoot values cannot escape the frame that created the associated root.
@@ -42,4 +43,20 @@ pub struct OCamlRawRootEscapeFailureCheck;
 ///     arg1_root
 /// });
 /// # ()
+/// ```
 pub struct OCamlRootEscapeFailureCheck;
+
+// Check that roots created from immediate values cannot escape.
+// Must fail with:
+// error[E0597]: `ocaml_n` does not live long enough
+/// ```compile_fail
+/// # use ocaml_interop::*;
+/// # ocaml! { pub fn ocaml_function(arg1: String) -> String; }
+/// # let cr = &mut OCamlRuntime::init();
+/// let escaped = {
+///     let ocaml_n: OCaml<'static, OCamlInt> = unsafe { OCaml::of_i64_unchecked(10) };
+///     ocaml_n.as_root()
+/// };
+/// # ()
+/// ```
+pub struct OCamlImmediateRootEscapeFailureCheck;

--- a/src/compile_ok_tests.rs
+++ b/src/compile_ok_tests.rs
@@ -1,0 +1,35 @@
+// Copyright (c) SimpleStaking and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+mod test_immediate_ocamlrefs {
+    // Test tests are just to confirm that AsRef for immediate OCaml values
+    // (ints, bools, etc) compiles correctly without the need for rooting those
+    // values.
+
+    use crate::*;
+
+    fn ocaml_fixnum_input(_cr: &mut OCamlRuntime, _: OCamlRef<OCamlInt>) {}
+    fn ocaml_bool_input(_cr: &mut OCamlRuntime, _: OCamlRef<bool>) {}
+    fn ocaml_option_input(_cr: &mut OCamlRuntime, _: OCamlRef<Option<String>>) {}
+    fn ocaml_unit_input(_cr: &mut OCamlRuntime, _: OCamlRef<()>) {}
+
+    fn test_immediate_ocamlref(cr: &mut OCamlRuntime) -> bool {
+        let i: OCaml<OCamlInt> = OCaml::of_i32(10);
+        let b: OCaml<bool> = OCaml::of_bool(true);
+        let n: OCaml<Option<String>> = OCaml::none();
+        let u: OCaml<()> = OCaml::unit();
+
+        ocaml_fixnum_input(cr, &i);
+        ocaml_bool_input(cr, &b);
+        ocaml_option_input(cr, &n);
+        ocaml_unit_input(cr, &u);
+
+        true
+    }
+
+    #[test]
+    fn test_immediate_ocamlrefs() {
+        let mut cr = unsafe { OCamlRuntime::recover_handle() };
+        assert!(test_immediate_ocamlref(&mut cr));
+    }
+}

--- a/src/conv/from_ocaml.rs
+++ b/src/conv/from_ocaml.rs
@@ -14,13 +14,13 @@ pub unsafe trait FromOCaml<T> {
 
 unsafe impl FromOCaml<OCamlInt> for i64 {
     fn from_ocaml(v: OCaml<OCamlInt>) -> Self {
-        v.as_i64()
+        v.to_i64()
     }
 }
 
 unsafe impl FromOCaml<OCamlInt> for i32 {
     fn from_ocaml(v: OCaml<OCamlInt>) -> Self {
-        v.as_i64() as i32
+        v.to_i64() as i32
     }
 }
 
@@ -40,7 +40,7 @@ unsafe impl FromOCaml<OCamlInt64> for i64 {
 
 unsafe impl FromOCaml<bool> for bool {
     fn from_ocaml(v: OCaml<bool>) -> Self {
-        v.as_bool()
+        v.to_bool()
     }
 }
 

--- a/src/conv/from_ocaml.rs
+++ b/src/conv/from_ocaml.rs
@@ -9,49 +9,49 @@ use crate::{
 /// Implements conversion from OCaml values into Rust values.
 pub unsafe trait FromOCaml<T> {
     /// Convert from OCaml value.
-    fn from_ocaml(v: OCaml<T>) -> Self;
+    fn from_ocaml(v: &OCaml<T>) -> Self;
 }
 
 unsafe impl FromOCaml<OCamlInt> for i64 {
-    fn from_ocaml(v: OCaml<OCamlInt>) -> Self {
+    fn from_ocaml(v: &OCaml<OCamlInt>) -> Self {
         v.to_i64()
     }
 }
 
 unsafe impl FromOCaml<OCamlInt> for i32 {
-    fn from_ocaml(v: OCaml<OCamlInt>) -> Self {
+    fn from_ocaml(v: &OCaml<OCamlInt>) -> Self {
         v.to_i64() as i32
     }
 }
 
 unsafe impl FromOCaml<OCamlInt32> for i32 {
-    fn from_ocaml(v: OCaml<OCamlInt32>) -> Self {
+    fn from_ocaml(v: &OCaml<OCamlInt32>) -> Self {
         let val = unsafe { field_val(v.raw(), 1) };
         unsafe { *(val as *const i32) }
     }
 }
 
 unsafe impl FromOCaml<OCamlInt64> for i64 {
-    fn from_ocaml(v: OCaml<OCamlInt64>) -> Self {
+    fn from_ocaml(v: &OCaml<OCamlInt64>) -> Self {
         let val = unsafe { field_val(v.raw(), 1) };
         unsafe { *(val as *const i64) }
     }
 }
 
 unsafe impl FromOCaml<bool> for bool {
-    fn from_ocaml(v: OCaml<bool>) -> Self {
+    fn from_ocaml(v: &OCaml<bool>) -> Self {
         v.to_bool()
     }
 }
 
 unsafe impl FromOCaml<OCamlFloat> for f64 {
-    fn from_ocaml(v: OCaml<OCamlFloat>) -> Self {
+    fn from_ocaml(v: &OCaml<OCamlFloat>) -> Self {
         unsafe { *(v.raw() as *const f64) }
     }
 }
 
 unsafe impl FromOCaml<String> for Vec<u8> {
-    fn from_ocaml(v: OCaml<String>) -> Self {
+    fn from_ocaml(v: &OCaml<String>) -> Self {
         let raw_bytes = v.as_bytes();
         let mut vec: Vec<u8> = Vec::with_capacity(raw_bytes.len());
         vec.extend_from_slice(raw_bytes);
@@ -60,13 +60,13 @@ unsafe impl FromOCaml<String> for Vec<u8> {
 }
 
 unsafe impl FromOCaml<String> for String {
-    fn from_ocaml(v: OCaml<String>) -> Self {
+    fn from_ocaml(v: &OCaml<String>) -> Self {
         v.as_str().to_owned()
     }
 }
 
 unsafe impl FromOCaml<OCamlBytes> for Vec<u8> {
-    fn from_ocaml(v: OCaml<OCamlBytes>) -> Self {
+    fn from_ocaml(v: &OCaml<OCamlBytes>) -> Self {
         let raw_bytes = v.as_bytes();
         let mut vec: Vec<u8> = Vec::with_capacity(raw_bytes.len());
         vec.extend_from_slice(raw_bytes);
@@ -75,13 +75,13 @@ unsafe impl FromOCaml<OCamlBytes> for Vec<u8> {
 }
 
 unsafe impl FromOCaml<OCamlBytes> for String {
-    fn from_ocaml(v: OCaml<OCamlBytes>) -> Self {
+    fn from_ocaml(v: &OCaml<OCamlBytes>) -> Self {
         unsafe { v.as_str_unchecked() }.to_owned()
     }
 }
 
 unsafe impl<OCamlT, T: FromOCaml<OCamlT>> FromOCaml<OCamlT> for Box<T> {
-    fn from_ocaml(v: OCaml<OCamlT>) -> Self {
+    fn from_ocaml(v: &OCaml<OCamlT>) -> Self {
         Box::new(T::from_ocaml(v))
     }
 }
@@ -91,10 +91,10 @@ where
     A: FromOCaml<OCamlA>,
     Err: FromOCaml<OCamlErr>,
 {
-    fn from_ocaml(v: OCaml<Result<OCamlA, OCamlErr>>) -> Self {
+    fn from_ocaml(v: &OCaml<Result<OCamlA, OCamlErr>>) -> Self {
         match v.to_result() {
-            Ok(ocaml_ok) => Ok(A::from_ocaml(ocaml_ok)),
-            Err(ocaml_err) => Err(Err::from_ocaml(ocaml_err)),
+            Ok(ocaml_ok) => Ok(A::from_ocaml(&ocaml_ok)),
+            Err(ocaml_err) => Err(Err::from_ocaml(&ocaml_err)),
         }
     }
 }
@@ -103,9 +103,9 @@ unsafe impl<A, OCamlA> FromOCaml<Option<OCamlA>> for Option<A>
 where
     A: FromOCaml<OCamlA>,
 {
-    fn from_ocaml(v: OCaml<Option<OCamlA>>) -> Self {
+    fn from_ocaml(v: &OCaml<Option<OCamlA>>) -> Self {
         if let Some(value) = v.to_option() {
-            Some(A::from_ocaml(value))
+            Some(A::from_ocaml(&value))
         } else {
             None
         }
@@ -117,8 +117,8 @@ where
     A: FromOCaml<OCamlA>,
     B: FromOCaml<OCamlB>,
 {
-    fn from_ocaml(v: OCaml<(OCamlA, OCamlB)>) -> Self {
-        (A::from_ocaml(v.fst()), B::from_ocaml(v.snd()))
+    fn from_ocaml(v: &OCaml<(OCamlA, OCamlB)>) -> Self {
+        (A::from_ocaml(&v.fst()), B::from_ocaml(&v.snd()))
     }
 }
 
@@ -128,11 +128,11 @@ where
     B: FromOCaml<OCamlB>,
     C: FromOCaml<OCamlC>,
 {
-    fn from_ocaml(v: OCaml<(OCamlA, OCamlB, OCamlC)>) -> Self {
+    fn from_ocaml(v: &OCaml<(OCamlA, OCamlB, OCamlC)>) -> Self {
         (
-            A::from_ocaml(v.fst()),
-            B::from_ocaml(v.snd()),
-            C::from_ocaml(v.tuple_3()),
+            A::from_ocaml(&v.fst()),
+            B::from_ocaml(&v.snd()),
+            C::from_ocaml(&v.tuple_3()),
         )
     }
 }
@@ -145,12 +145,12 @@ where
     C: FromOCaml<OCamlC>,
     D: FromOCaml<OCamlD>,
 {
-    fn from_ocaml(v: OCaml<(OCamlA, OCamlB, OCamlC, OCamlD)>) -> Self {
+    fn from_ocaml(v: &OCaml<(OCamlA, OCamlB, OCamlC, OCamlD)>) -> Self {
         (
-            A::from_ocaml(v.fst()),
-            B::from_ocaml(v.snd()),
-            C::from_ocaml(v.tuple_3()),
-            D::from_ocaml(v.tuple_4()),
+            A::from_ocaml(&v.fst()),
+            B::from_ocaml(&v.snd()),
+            C::from_ocaml(&v.tuple_3()),
+            D::from_ocaml(&v.tuple_4()),
         )
     }
 }
@@ -159,13 +159,13 @@ unsafe impl<A, OCamlA> FromOCaml<OCamlList<OCamlA>> for Vec<A>
 where
     A: FromOCaml<OCamlA>,
 {
-    fn from_ocaml(v: OCaml<OCamlList<OCamlA>>) -> Self {
+    fn from_ocaml(v: &OCaml<OCamlList<OCamlA>>) -> Self {
         // TODO: pre-calculate actual required capacity?
         let mut vec = Vec::new();
-        let mut current = v;
+        let mut current = v.clone();
         while let Some((hd, tl)) = current.uncons() {
             current = tl;
-            vec.push(A::from_ocaml(hd));
+            vec.push(A::from_ocaml(&hd));
         }
         vec
     }

--- a/src/conv/from_ocaml.rs
+++ b/src/conv/from_ocaml.rs
@@ -9,49 +9,49 @@ use crate::{
 /// Implements conversion from OCaml values into Rust values.
 pub unsafe trait FromOCaml<T> {
     /// Convert from OCaml value.
-    fn from_ocaml(v: &OCaml<T>) -> Self;
+    fn from_ocaml(v: OCaml<T>) -> Self;
 }
 
 unsafe impl FromOCaml<OCamlInt> for i64 {
-    fn from_ocaml(v: &OCaml<OCamlInt>) -> Self {
+    fn from_ocaml(v: OCaml<OCamlInt>) -> Self {
         v.to_i64()
     }
 }
 
 unsafe impl FromOCaml<OCamlInt> for i32 {
-    fn from_ocaml(v: &OCaml<OCamlInt>) -> Self {
+    fn from_ocaml(v: OCaml<OCamlInt>) -> Self {
         v.to_i64() as i32
     }
 }
 
 unsafe impl FromOCaml<OCamlInt32> for i32 {
-    fn from_ocaml(v: &OCaml<OCamlInt32>) -> Self {
+    fn from_ocaml(v: OCaml<OCamlInt32>) -> Self {
         let val = unsafe { field_val(v.raw(), 1) };
         unsafe { *(val as *const i32) }
     }
 }
 
 unsafe impl FromOCaml<OCamlInt64> for i64 {
-    fn from_ocaml(v: &OCaml<OCamlInt64>) -> Self {
+    fn from_ocaml(v: OCaml<OCamlInt64>) -> Self {
         let val = unsafe { field_val(v.raw(), 1) };
         unsafe { *(val as *const i64) }
     }
 }
 
 unsafe impl FromOCaml<bool> for bool {
-    fn from_ocaml(v: &OCaml<bool>) -> Self {
+    fn from_ocaml(v: OCaml<bool>) -> Self {
         v.to_bool()
     }
 }
 
 unsafe impl FromOCaml<OCamlFloat> for f64 {
-    fn from_ocaml(v: &OCaml<OCamlFloat>) -> Self {
+    fn from_ocaml(v: OCaml<OCamlFloat>) -> Self {
         unsafe { *(v.raw() as *const f64) }
     }
 }
 
 unsafe impl FromOCaml<String> for Vec<u8> {
-    fn from_ocaml(v: &OCaml<String>) -> Self {
+    fn from_ocaml(v: OCaml<String>) -> Self {
         let raw_bytes = v.as_bytes();
         let mut vec: Vec<u8> = Vec::with_capacity(raw_bytes.len());
         vec.extend_from_slice(raw_bytes);
@@ -60,13 +60,13 @@ unsafe impl FromOCaml<String> for Vec<u8> {
 }
 
 unsafe impl FromOCaml<String> for String {
-    fn from_ocaml(v: &OCaml<String>) -> Self {
+    fn from_ocaml(v: OCaml<String>) -> Self {
         String::from_utf8_lossy(v.as_bytes()).into_owned()
     }
 }
 
 unsafe impl FromOCaml<OCamlBytes> for Vec<u8> {
-    fn from_ocaml(v: &OCaml<OCamlBytes>) -> Self {
+    fn from_ocaml(v: OCaml<OCamlBytes>) -> Self {
         let raw_bytes = v.as_bytes();
         let mut vec: Vec<u8> = Vec::with_capacity(raw_bytes.len());
         vec.extend_from_slice(raw_bytes);
@@ -75,13 +75,13 @@ unsafe impl FromOCaml<OCamlBytes> for Vec<u8> {
 }
 
 unsafe impl FromOCaml<OCamlBytes> for String {
-    fn from_ocaml(v: &OCaml<OCamlBytes>) -> Self {
+    fn from_ocaml(v: OCaml<OCamlBytes>) -> Self {
         unsafe { v.as_str_unchecked() }.to_owned()
     }
 }
 
 unsafe impl<OCamlT, T: FromOCaml<OCamlT>> FromOCaml<OCamlT> for Box<T> {
-    fn from_ocaml(v: &OCaml<OCamlT>) -> Self {
+    fn from_ocaml(v: OCaml<OCamlT>) -> Self {
         Box::new(T::from_ocaml(v))
     }
 }
@@ -91,10 +91,10 @@ where
     A: FromOCaml<OCamlA>,
     Err: FromOCaml<OCamlErr>,
 {
-    fn from_ocaml(v: &OCaml<Result<OCamlA, OCamlErr>>) -> Self {
+    fn from_ocaml(v: OCaml<Result<OCamlA, OCamlErr>>) -> Self {
         match v.to_result() {
-            Ok(ocaml_ok) => Ok(A::from_ocaml(&ocaml_ok)),
-            Err(ocaml_err) => Err(Err::from_ocaml(&ocaml_err)),
+            Ok(ocaml_ok) => Ok(A::from_ocaml(ocaml_ok)),
+            Err(ocaml_err) => Err(Err::from_ocaml(ocaml_err)),
         }
     }
 }
@@ -103,9 +103,9 @@ unsafe impl<A, OCamlA> FromOCaml<Option<OCamlA>> for Option<A>
 where
     A: FromOCaml<OCamlA>,
 {
-    fn from_ocaml(v: &OCaml<Option<OCamlA>>) -> Self {
+    fn from_ocaml(v: OCaml<Option<OCamlA>>) -> Self {
         if let Some(value) = v.to_option() {
-            Some(A::from_ocaml(&value))
+            Some(A::from_ocaml(value))
         } else {
             None
         }
@@ -117,8 +117,8 @@ where
     A: FromOCaml<OCamlA>,
     B: FromOCaml<OCamlB>,
 {
-    fn from_ocaml(v: &OCaml<(OCamlA, OCamlB)>) -> Self {
-        (A::from_ocaml(&v.fst()), B::from_ocaml(&v.snd()))
+    fn from_ocaml(v: OCaml<(OCamlA, OCamlB)>) -> Self {
+        (A::from_ocaml(v.fst()), B::from_ocaml(v.snd()))
     }
 }
 
@@ -128,11 +128,11 @@ where
     B: FromOCaml<OCamlB>,
     C: FromOCaml<OCamlC>,
 {
-    fn from_ocaml(v: &OCaml<(OCamlA, OCamlB, OCamlC)>) -> Self {
+    fn from_ocaml(v: OCaml<(OCamlA, OCamlB, OCamlC)>) -> Self {
         (
-            A::from_ocaml(&v.fst()),
-            B::from_ocaml(&v.snd()),
-            C::from_ocaml(&v.tuple_3()),
+            A::from_ocaml(v.fst()),
+            B::from_ocaml(v.snd()),
+            C::from_ocaml(v.tuple_3()),
         )
     }
 }
@@ -145,12 +145,12 @@ where
     C: FromOCaml<OCamlC>,
     D: FromOCaml<OCamlD>,
 {
-    fn from_ocaml(v: &OCaml<(OCamlA, OCamlB, OCamlC, OCamlD)>) -> Self {
+    fn from_ocaml(v: OCaml<(OCamlA, OCamlB, OCamlC, OCamlD)>) -> Self {
         (
-            A::from_ocaml(&v.fst()),
-            B::from_ocaml(&v.snd()),
-            C::from_ocaml(&v.tuple_3()),
-            D::from_ocaml(&v.tuple_4()),
+            A::from_ocaml(v.fst()),
+            B::from_ocaml(v.snd()),
+            C::from_ocaml(v.tuple_3()),
+            D::from_ocaml(v.tuple_4()),
         )
     }
 }
@@ -159,13 +159,13 @@ unsafe impl<A, OCamlA> FromOCaml<OCamlList<OCamlA>> for Vec<A>
 where
     A: FromOCaml<OCamlA>,
 {
-    fn from_ocaml(v: &OCaml<OCamlList<OCamlA>>) -> Self {
+    fn from_ocaml(v: OCaml<OCamlList<OCamlA>>) -> Self {
         // TODO: pre-calculate actual required capacity?
         let mut vec = Vec::new();
         let mut current = v.clone();
         while let Some((hd, tl)) = current.uncons() {
             current = tl;
-            vec.push(A::from_ocaml(&hd));
+            vec.push(A::from_ocaml(hd));
         }
         vec
     }

--- a/src/conv/from_ocaml.rs
+++ b/src/conv/from_ocaml.rs
@@ -61,7 +61,7 @@ unsafe impl FromOCaml<String> for Vec<u8> {
 
 unsafe impl FromOCaml<String> for String {
     fn from_ocaml(v: &OCaml<String>) -> Self {
-        v.as_str().to_owned()
+        String::from_utf8_lossy(v.as_bytes()).into_owned()
     }
 }
 

--- a/src/conv/from_ocaml.rs
+++ b/src/conv/from_ocaml.rs
@@ -162,7 +162,7 @@ where
     fn from_ocaml(v: OCaml<OCamlList<OCamlA>>) -> Self {
         // TODO: pre-calculate actual required capacity?
         let mut vec = Vec::new();
-        let mut current = v.clone();
+        let mut current = v;
         while let Some((hd, tl)) = current.uncons() {
             current = tl;
             vec.push(A::from_ocaml(hd));

--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -30,7 +30,7 @@ pub unsafe trait ToOCaml<T> {
 
 unsafe impl<'a, T> ToOCaml<T> for OCamlRooted<'a, T> {
     fn to_ocaml(&self, _token: OCamlAllocToken) -> OCamlAllocResult<T> {
-        OCamlAllocResult::of(self.get_raw())
+        OCamlAllocResult::of(unsafe { self.get_raw() })
     }
 }
 

--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -4,20 +4,13 @@
 use core::str;
 use ocaml_sys::{caml_alloc, store_field};
 
-use crate::{
-    memory::{
+use crate::{OCamlRuntime, memory::{
         alloc_bytes, alloc_cons, alloc_double, alloc_int32, alloc_int64, alloc_some, alloc_string,
-        alloc_tuple, alloc_tuple_3, alloc_tuple_4, OCamlAllocResult, OCamlRooted,
-    },
-    mlvalues::{
+        alloc_tuple, alloc_tuple_3, alloc_tuple_4, OCamlRooted,
+    }, mlvalues::{
         tag, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, RawOCaml, FALSE,
         NONE, TRUE,
-    },
-    ocaml_alloc, ocaml_frame,
-    runtime::OCamlAllocToken,
-    to_ocaml,
-    value::OCaml,
-};
+    }, ocaml_frame, to_ocaml, value::OCaml};
 
 /// Implements conversion from Rust values into OCaml values.
 pub unsafe trait ToOCaml<T> {
@@ -25,96 +18,96 @@ pub unsafe trait ToOCaml<T> {
     ///
     /// Should not be called directly, use [`to_ocaml!`] macro instead.
     /// If called directly, the call should be wrapped by [`ocaml_alloc!`].
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<T>;
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T>;
 }
 
-unsafe impl<'a, T> ToOCaml<T> for OCamlRooted<'a, T> {
-    fn to_ocaml(&self, _token: OCamlAllocToken) -> OCamlAllocResult<T> {
-        OCamlAllocResult::of(unsafe { self.get_raw() })
+unsafe impl<'root, T> ToOCaml<T> for OCamlRooted<'root, T> {
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T> {
+        unsafe { OCaml::new(cr, self.get_raw()) }
     }
 }
 
 unsafe impl ToOCaml<OCamlInt> for i64 {
-    fn to_ocaml(&self, _token: OCamlAllocToken) -> OCamlAllocResult<OCamlInt> {
-        OCamlAllocResult::of(((self << 1) | 1) as RawOCaml)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt> {
+        unsafe { OCaml::new(cr, ((self << 1) | 1) as RawOCaml) }
     }
 }
 
 unsafe impl ToOCaml<OCamlInt> for i32 {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<OCamlInt> {
-        (*self as i64).to_ocaml(token)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt> {
+        (*self as i64).to_ocaml(cr)
     }
 }
 
 unsafe impl ToOCaml<OCamlInt32> for i32 {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<OCamlInt32> {
-        alloc_int32(token, *self)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt32> {
+        alloc_int32(cr, *self)
     }
 }
 
 unsafe impl ToOCaml<OCamlInt64> for i64 {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<OCamlInt64> {
-        alloc_int64(token, *self)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt64> {
+        alloc_int64(cr, *self)
     }
 }
 
 unsafe impl ToOCaml<OCamlFloat> for f64 {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<OCamlFloat> {
-        alloc_double(token, *self)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlFloat> {
+        alloc_double(cr, *self)
     }
 }
 
 unsafe impl ToOCaml<bool> for bool {
-    fn to_ocaml(&self, _token: OCamlAllocToken) -> OCamlAllocResult<bool> {
-        OCamlAllocResult::of(if *self { TRUE } else { FALSE })
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, bool> {
+        unsafe { OCaml::new(cr, if *self { TRUE } else { FALSE }) }
     }
 }
 
 unsafe impl ToOCaml<String> for &str {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<String> {
-        alloc_string(token, self)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
+        alloc_string(cr, self)
     }
 }
 
 unsafe impl ToOCaml<OCamlBytes> for &str {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<OCamlBytes> {
-        alloc_bytes(token, self.as_bytes())
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
+        alloc_bytes(cr, self.as_bytes())
     }
 }
 
 unsafe impl ToOCaml<OCamlBytes> for &[u8] {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<OCamlBytes> {
-        alloc_bytes(token, self)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
+        alloc_bytes(cr, self)
     }
 }
 
 unsafe impl ToOCaml<String> for &[u8] {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<String> {
-        alloc_string(token, unsafe { str::from_utf8_unchecked(self) })
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
+        alloc_string(cr, unsafe { str::from_utf8_unchecked(self) })
     }
 }
 
 unsafe impl ToOCaml<String> for String {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<String> {
-        self.as_str().to_ocaml(token)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
+        self.as_str().to_ocaml(cr)
     }
 }
 
 unsafe impl ToOCaml<OCamlBytes> for String {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<OCamlBytes> {
-        self.as_str().to_ocaml(token)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
+        self.as_str().to_ocaml(cr)
     }
 }
 
 unsafe impl ToOCaml<String> for Vec<u8> {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<String> {
-        self.as_slice().to_ocaml(token)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, String> {
+        self.as_slice().to_ocaml(cr)
     }
 }
 
 unsafe impl ToOCaml<OCamlBytes> for Vec<u8> {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<OCamlBytes> {
-        self.as_slice().to_ocaml(token)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlBytes> {
+        self.as_slice().to_ocaml(cr)
     }
 }
 
@@ -122,8 +115,8 @@ unsafe impl<A, OCamlA> ToOCaml<OCamlA> for Box<A>
 where
     A: ToOCaml<OCamlA>,
 {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<OCamlA> {
-        self.as_ref().to_ocaml(token)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlA> {
+        self.as_ref().to_ocaml(cr)
     }
 }
 
@@ -131,15 +124,14 @@ unsafe impl<A, OCamlA> ToOCaml<Option<OCamlA>> for Option<A>
 where
     A: ToOCaml<OCamlA>,
 {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<Option<OCamlA>> {
-        let cr = unsafe { &mut token.recover_runtime_handle() };
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, Option<OCamlA>> {
         if let Some(value) = self {
             ocaml_frame!(cr, (root), {
                 let ocaml_value = to_ocaml!(cr, value, root);
-                alloc_some(unsafe { cr.token() }, &ocaml_value)
+                alloc_some(cr, &ocaml_value)
             })
         } else {
-            OCamlAllocResult::of(NONE)
+            unsafe { OCaml::new(cr, NONE) }
         }
     }
 }
@@ -149,20 +141,19 @@ where
     A: ToOCaml<OCamlA>,
     Err: ToOCaml<OCamlErr>,
 {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<Result<OCamlA, OCamlErr>> {
-        let cr = unsafe { &mut token.recover_runtime_handle() };
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, Result<OCamlA, OCamlErr>> {
         match self {
             Ok(value) => ocaml_frame!(cr, (root), {
                 let ocaml_value = to_ocaml!(cr, value, root);
                 let ocaml_ok = unsafe { caml_alloc(1, tag::TAG_OK) };
                 unsafe { store_field(ocaml_ok, 0, ocaml_value.get_raw()) };
-                OCamlAllocResult::of(ocaml_ok)
+                unsafe { OCaml::new(cr, ocaml_ok) }
             }),
             Err(error) => ocaml_frame!(cr, (root), {
                 let ocaml_error = to_ocaml!(cr, error, root);
                 let ocaml_err = unsafe { caml_alloc(1, tag::TAG_ERROR) };
                 unsafe { store_field(ocaml_err, 0, ocaml_error.get_raw()) };
-                OCamlAllocResult::of(ocaml_err)
+                unsafe { OCaml::new(cr, ocaml_err) }
             }),
         }
     }
@@ -173,12 +164,11 @@ where
     A: ToOCaml<OCamlA>,
     B: ToOCaml<OCamlB>,
 {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<(OCamlA, OCamlB)> {
-        let cr = unsafe { &mut token.recover_runtime_handle() };
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, (OCamlA, OCamlB)> {
         ocaml_frame!(cr, (fst, snd), {
             let fst = to_ocaml!(cr, self.0, fst);
             let snd = to_ocaml!(cr, self.1, snd);
-            alloc_tuple(unsafe { cr.token() }, &fst, &snd)
+            alloc_tuple(cr, &fst, &snd)
         })
     }
 }
@@ -189,13 +179,12 @@ where
     B: ToOCaml<OCamlB>,
     C: ToOCaml<OCamlC>,
 {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<(OCamlA, OCamlB, OCamlC)> {
-        let cr = unsafe { &mut token.recover_runtime_handle() };
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, (OCamlA, OCamlB, OCamlC)> {
         ocaml_frame!(cr, (fst, snd, elt3), {
             let fst = to_ocaml!(cr, self.0, fst);
             let snd = to_ocaml!(cr, self.1, snd);
             let elt3 = to_ocaml!(cr, self.2, elt3);
-            alloc_tuple_3(unsafe { cr.token() }, &fst, &snd, &elt3)
+            alloc_tuple_3(cr, &fst, &snd, &elt3)
         })
     }
 }
@@ -208,17 +197,16 @@ where
     C: ToOCaml<OCamlC>,
     D: ToOCaml<OCamlD>,
 {
-    fn to_ocaml(
+    fn to_ocaml<'a>(
         &self,
-        token: OCamlAllocToken,
-    ) -> OCamlAllocResult<(OCamlA, OCamlB, OCamlC, OCamlD)> {
-        let cr = unsafe { &mut token.recover_runtime_handle() };
+        cr: &'a mut OCamlRuntime,
+    ) -> OCaml<'a, (OCamlA, OCamlB, OCamlC, OCamlD)> {
         ocaml_frame!(cr, (fst, snd, elt3, elt4), {
             let fst = to_ocaml!(cr, self.0, fst);
             let snd = to_ocaml!(cr, self.1, snd);
             let elt3 = to_ocaml!(cr, self.2, elt3);
             let elt4 = to_ocaml!(cr, self.3, elt4);
-            alloc_tuple_4(unsafe { cr.token() }, &fst, &snd, &elt3, &elt4)
+            alloc_tuple_4(cr, &fst, &snd, &elt3, &elt4)
         })
     }
 }
@@ -227,8 +215,8 @@ unsafe impl<A, OCamlA> ToOCaml<OCamlList<OCamlA>> for Vec<A>
 where
     A: ToOCaml<OCamlA>,
 {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<OCamlList<OCamlA>> {
-        (&self).to_ocaml(token)
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlList<OCamlA>> {
+        (&self).to_ocaml(cr)
     }
 }
 
@@ -236,16 +224,15 @@ unsafe impl<A, OCamlA> ToOCaml<OCamlList<OCamlA>> for &Vec<A>
 where
     A: ToOCaml<OCamlA>,
 {
-    fn to_ocaml(&self, token: OCamlAllocToken) -> OCamlAllocResult<OCamlList<OCamlA>> {
-        let cr = unsafe { &mut token.recover_runtime_handle() };
+    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlList<OCamlA>> {
         ocaml_frame!(cr, (result_root, ov_root), {
             let mut result_root = result_root.keep(OCaml::nil());
             for elt in self.iter().rev() {
                 let ov = to_ocaml!(cr, elt, ov_root);
-                let cons = ocaml_alloc!(alloc_cons(cr, &ov, &result_root));
+                let cons = alloc_cons(cr, &ov, &result_root);
                 result_root.set(cons);
             }
-            OCamlAllocResult::of_ocaml(cr.get(&result_root))
+            cr.get(&result_root)
         })
     }
 }

--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -132,7 +132,7 @@ where
         if let Some(value) = self {
             ocaml_frame!(cr, (root), {
                 let ocaml_value = to_ocaml!(cr, value, root);
-                alloc_some(cr, &ocaml_value)
+                alloc_some(cr, ocaml_value)
             })
         } else {
             unsafe { OCaml::new(cr, NONE) }
@@ -172,7 +172,7 @@ where
         ocaml_frame!(cr, (fst, snd), {
             let fst = to_ocaml!(cr, self.0, fst);
             let snd = to_ocaml!(cr, self.1, snd);
-            alloc_tuple(cr, &fst, &snd)
+            alloc_tuple(cr, fst, snd)
         })
     }
 }
@@ -188,7 +188,7 @@ where
             let fst = to_ocaml!(cr, self.0, fst);
             let snd = to_ocaml!(cr, self.1, snd);
             let elt3 = to_ocaml!(cr, self.2, elt3);
-            alloc_tuple_3(cr, &fst, &snd, &elt3)
+            alloc_tuple_3(cr, fst, snd, elt3)
         })
     }
 }
@@ -210,7 +210,7 @@ where
             let snd = to_ocaml!(cr, self.1, snd);
             let elt3 = to_ocaml!(cr, self.2, elt3);
             let elt4 = to_ocaml!(cr, self.3, elt4);
-            alloc_tuple_4(cr, &fst, &snd, &elt3, &elt4)
+            alloc_tuple_4(cr, fst, snd, elt3, elt4)
         })
     }
 }
@@ -233,10 +233,10 @@ where
             let mut result = result_root.keep(OCaml::nil());
             for elt in self.iter().rev() {
                 let ov = to_ocaml!(cr, elt, ov_root);
-                let cons = alloc_cons(cr, &ov, &result);
+                let cons = alloc_cons(cr, ov, result);
                 result = result_root.keep(cons);
             }
-            cr.get(&result)
+            cr.get(result)
         })
     }
 }

--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -7,7 +7,7 @@ use ocaml_sys::{caml_alloc, store_field};
 use crate::{
     memory::{
         alloc_bytes, alloc_cons, alloc_double, alloc_int32, alloc_int64, alloc_some, alloc_string,
-        alloc_tuple, alloc_tuple_3, alloc_tuple_4, OCamlRoot,
+        alloc_tuple, alloc_tuple_3, alloc_tuple_4, OCamlRef,
     },
     mlvalues::{
         tag, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, RawOCaml, FALSE,
@@ -25,7 +25,7 @@ pub unsafe trait ToOCaml<T> {
     fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T>;
 }
 
-unsafe impl<'root, T> ToOCaml<T> for OCamlRoot<'root, T> {
+unsafe impl<'root, T> ToOCaml<T> for OCamlRef<'root, T> {
     fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T> {
         unsafe { OCaml::new(cr, self.get_raw()) }
     }
@@ -230,13 +230,13 @@ where
 {
     fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlList<OCamlA>> {
         ocaml_frame!(cr, (result_root, ov_root), {
-            let mut result_root = result_root.keep(OCaml::nil());
+            let mut result = result_root.keep(OCaml::nil());
             for elt in self.iter().rev() {
                 let ov = to_ocaml!(cr, elt, ov_root);
-                let cons = alloc_cons(cr, &ov, &result_root);
-                result_root.set(cons);
+                let cons = alloc_cons(cr, &ov, &result);
+                result = result_root.keep(cons);
             }
-            cr.get(&result_root)
+            cr.get(&result)
         })
     }
 }

--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -15,9 +15,6 @@ use crate::{OCamlRuntime, memory::{
 /// Implements conversion from Rust values into OCaml values.
 pub unsafe trait ToOCaml<T> {
     /// Convert to OCaml value.
-    ///
-    /// Should not be called directly, use [`to_ocaml!`] macro instead.
-    /// If called directly, the call should be wrapped by [`ocaml_alloc!`].
     fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T>;
 }
 

--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -4,13 +4,20 @@
 use core::str;
 use ocaml_sys::{caml_alloc, store_field};
 
-use crate::{OCamlRuntime, memory::{
+use crate::{
+    memory::{
         alloc_bytes, alloc_cons, alloc_double, alloc_int32, alloc_int64, alloc_some, alloc_string,
         alloc_tuple, alloc_tuple_3, alloc_tuple_4, OCamlRooted,
-    }, mlvalues::{
+    },
+    mlvalues::{
         tag, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, RawOCaml, FALSE,
         NONE, TRUE,
-    }, ocaml_frame, to_ocaml, value::OCaml};
+    },
+    ocaml_frame,
+    runtime::OCamlRuntime,
+    to_ocaml,
+    value::OCaml,
+};
 
 /// Implements conversion from Rust values into OCaml values.
 pub unsafe trait ToOCaml<T> {

--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -7,7 +7,7 @@ use ocaml_sys::{caml_alloc, store_field};
 use crate::{
     memory::{
         alloc_bytes, alloc_cons, alloc_double, alloc_int32, alloc_int64, alloc_some, alloc_string,
-        alloc_tuple, alloc_tuple_3, alloc_tuple_4, OCamlRooted,
+        alloc_tuple, alloc_tuple_3, alloc_tuple_4, OCamlRoot,
     },
     mlvalues::{
         tag, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, RawOCaml, FALSE,
@@ -25,7 +25,7 @@ pub unsafe trait ToOCaml<T> {
     fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T>;
 }
 
-unsafe impl<'root, T> ToOCaml<T> for OCamlRooted<'root, T> {
+unsafe impl<'root, T> ToOCaml<T> for OCamlRoot<'root, T> {
     fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, T> {
         unsafe { OCaml::new(cr, self.get_raw()) }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,17 +4,12 @@
 use crate::mlvalues::{is_block, string_val, tag_val, RawOCaml};
 use crate::mlvalues::{tag, MAX_FIXNUM, MIN_FIXNUM};
 use core::{fmt, slice};
-use ocaml_sys::caml_string_length;
+use ocaml_sys::{caml_string_length, is_exception_result};
 
 /// An OCaml exception value.
 #[derive(Debug)]
 pub struct OCamlException {
     raw: RawOCaml,
-}
-
-#[derive(Debug)]
-pub enum OCamlError {
-    Exception(OCamlException),
 }
 
 #[derive(Debug)]
@@ -42,6 +37,7 @@ impl fmt::Display for OCamlFixnumConversionError {
 
 impl OCamlException {
     pub fn of(raw: RawOCaml) -> Self {
+        assert!(is_exception_result(raw));
         OCamlException { raw }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,7 @@ impl fmt::Display for OCamlFixnumConversionError {
 }
 
 impl OCamlException {
+    #[doc(hidden)]
     pub unsafe fn of(raw: RawOCaml) -> Self {
         OCamlException { raw }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,8 +36,7 @@ impl fmt::Display for OCamlFixnumConversionError {
 }
 
 impl OCamlException {
-    pub fn of(raw: RawOCaml) -> Self {
-        assert!(is_exception_result(raw));
+    pub unsafe fn of(raw: RawOCaml) -> Self {
         OCamlException { raw }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,7 +46,7 @@ impl OCamlException {
             unsafe {
                 let message = *(self.raw as *const RawOCaml).add(1);
 
-                if tag_val(message) == tag::STRING {
+                if is_block(message) && tag_val(message) == tag::STRING {
                     let error_message =
                         slice::from_raw_parts(string_val(message), caml_string_length(message))
                             .to_owned();

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 use crate::mlvalues::{is_block, string_val, tag_val, RawOCaml};
 use crate::mlvalues::{tag, MAX_FIXNUM, MIN_FIXNUM};
 use core::{fmt, slice};
-use ocaml_sys::{caml_string_length, is_exception_result};
+use ocaml_sys::caml_string_length;
 
 /// An OCaml exception value.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,7 +402,7 @@ mod value;
 
 pub use crate::closure::{OCamlFn1, OCamlFn2, OCamlFn3, OCamlFn4, OCamlFn5};
 pub use crate::conv::{FromOCaml, ToOCaml};
-pub use crate::error::{OCamlError, OCamlException};
+pub use crate::error::OCamlException;
 pub use crate::memory::OCamlRooted;
 pub use crate::mlvalues::{
     OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, RawOCaml,
@@ -414,8 +414,8 @@ pub use crate::value::OCaml;
 pub mod internal {
     pub use crate::closure::OCamlClosure;
     pub use crate::memory::{caml_alloc, store_field, OCamlRoot};
-    pub use crate::mlvalues::UNIT;
     pub use crate::mlvalues::tag;
+    pub use crate::mlvalues::UNIT;
     pub use ocaml_sys::{caml_hash_variant, int_val};
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,10 +400,10 @@ mod mlvalues;
 mod runtime;
 mod value;
 
-pub use crate::closure::{OCamlFn1, OCamlFn2, OCamlFn3, OCamlFn4, OCamlFn5, OCamlResult};
+pub use crate::closure::{OCamlFn1, OCamlFn2, OCamlFn3, OCamlFn4, OCamlFn5};
 pub use crate::conv::{FromOCaml, ToOCaml};
 pub use crate::error::{OCamlError, OCamlException};
-pub use crate::memory::{OCamlAllocResult, OCamlRooted};
+pub use crate::memory::OCamlRooted;
 pub use crate::mlvalues::{
     OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, RawOCaml,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //!
 //! The [`FromOCaml`] trait implements conversion from OCaml values into Rust values, using the `from_ocaml` function.
 //!
-//! [`OCaml`]`<T>` values have a `to_rust()` method that is usually more convenient than `Type::from_ocaml(ocaml_value)`, and works for any combination that implements the `FromOCaml` trait.
+//! [`OCaml`]`<T>` values have a `to_rust()` method that is usually more convenient than `Type::from_ocaml(&ocaml_value)`, and works for any combination that implements the `FromOCaml` trait.
 //!
 //! [`OCamlRooted`]`<T>` values have a `to_rust(cr)` that needs an [`OCamlRuntime`] reference to be passed to it.
 //!
@@ -246,7 +246,7 @@
 //!         // OCaml runtime when converting into Rust values.
 //!         // A more convenient alternative, is to use the `to_rust` method as
 //!         // above when `result1` was converted.
-//!         (new_bytes1, String::from_ocaml(result2))
+//!         (new_bytes1, String::from_ocaml(&result2))
 //!     })
 //! }
 //!
@@ -255,7 +255,7 @@
 //!         let ocaml_num = unsafe { OCaml::of_i64_unchecked(num as i64) };
 //!         let num_rooted = &num_root.keep(ocaml_num);
 //!         let result = ocaml_funcs::twice(cr, num_rooted);
-//!         i64::from_ocaml(result) as usize
+//!         i64::from_ocaml(&result) as usize
 //!     })
 //! }
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@
 //!         // OCaml runtime when converting into Rust values.
 //!         // A more convenient alternative, is to use the `to_rust` method as
 //!         // above when `result1` was converted.
-//!         (new_bytes1, String::from_ocaml(&result2))
+//!         (new_bytes1, String::from_ocaml(result2))
 //!     })
 //! }
 //!
@@ -256,7 +256,7 @@
 //!         let ocaml_num = unsafe { OCaml::of_i64_unchecked(num as i64) };
 //!         let num_root = num_root.keep(ocaml_num);
 //!         let result = ocaml_funcs::twice(cr, num_root);
-//!         i64::from_ocaml(&result) as usize
+//!         i64::from_ocaml(result) as usize
 //!     })
 //! }
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 
 //! _Zinc-iron alloy coating is used in parts that need very good corrosion protection._
 //!
+//! **API IS CONSIDERED UNSTABLE AT THE MOMENT AND IS LIKELY TO CHANGE IN THE FUTURE**
+//!
 //! [ocaml-interop](https://github.com/simplestaking/ocaml-interop) is an OCaml<->Rust FFI with an emphasis on safety inspired by [caml-oxide](https://github.com/stedolan/caml-oxide) and [ocaml-rs](https://github.com/zshipko/ocaml-rs).
 //!
 //! ## Table of Contents

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@
 //!
 //! With this calling convention, values that are arguments to a function call must be rooted by the caller. Then instead of the value, it is the root pointing to the value that is passed as an argument. This is how `ocaml-interop` works starting with version `0.5.0`.
 //!
-//! When a Rust function is called from OCaml, it will receive arguments as `&OCamlRef<T>` values, and when a OCaml function is called from Rust, arguments will be passed as `&OCamlRef<T>` values.
+//! When a Rust function is called from OCaml, it will receive arguments as `OCamlRef<T>` values, and when a OCaml function is called from Rust, arguments will be passed as `OCamlRef<T>` values.
 //!
 //! ### Calling into OCaml from Rust
 //!
@@ -203,13 +203,13 @@
 //!         // an value-containing root that is going to be valid during the scope of
 //!         // the current `ocaml_frame!` block. Later `cr.get(value_root)` can be used
 //!         // to recover the original OCaml value.
-//!         let bytes1_root: &OCamlRef<String> = &bytes1_root.keep(ocaml_bytes1);
+//!         let bytes1_root: OCamlRef<String> = bytes1_root.keep(ocaml_bytes1);
 //!
 //!         // Same as above. Here the convenience macro [`to_ocaml!`] is used.
 //!         // It works like `value.to_ocaml(cr)`, but has an optional third argument that
 //!         // can be a root variable to perform the rooting.
 //!         // This variation returns an `OCamlRef` value instead of an `OCaml` one.
-//!         let bytes2_root = &to_ocaml!(cr, bytes2, bytes2_root);
+//!         let bytes2_root = to_ocaml!(cr, bytes2, bytes2_root);
 //!
 //!         // Rust `i64` integers can be converted into OCaml fixnums with `OCaml::of_i64`
 //!         // and `OCaml::of_i64_unchecked`.
@@ -220,13 +220,13 @@
 //!         // Any OCaml function (declared above in a `ocaml!` block) can be called as a regular
 //!         // Rust function, by passing a `&mut OCamlRuntime` as the first argument, followed by
 //!         // the rest of the arguments declared for that function.
-//!         // Arguments to these functions must be references to roots: `&OCamlRef<T>`
+//!         // Arguments to these functions must be references to roots: `OCamlRef<T>`
 //!         let result1 = ocaml_funcs::increment_bytes(
 //!             cr,             // &mut OCamlRuntime
-//!             bytes1_root,    // &OCamlRef<String>
+//!             bytes1_root,    // OCamlRef<String>
 //!             // Immediate OCaml values, such as ints and books have an as_value_ref() method
 //!             // that can be used to simulate rooting.
-//!             &ocaml_first_n.as_value_ref(), // &OCamlRef<OCamlInt>
+//!             ocaml_first_n.as_value_ref(), // OCamlRef<OCamlInt>
 //!         );
 //!
 //!         // Perform the conversion of the OCaml result value into a
@@ -238,7 +238,7 @@
 //!         let result2 = ocaml_funcs::increment_bytes(
 //!             cr,
 //!             bytes2_root,
-//!             &ocaml_first_n.as_value_ref(),
+//!             ocaml_first_n.as_value_ref(),
 //!         );
 //!
 //!         // The `FromOCaml` trait provides the `from_ocaml` method to convert from
@@ -254,7 +254,7 @@
 //! fn twice(cr: &mut OCamlRuntime, num: usize) -> usize {
 //!     ocaml_frame!(cr, (num_root), {
 //!         let ocaml_num = unsafe { OCaml::of_i64_unchecked(num as i64) };
-//!         let num_root = &num_root.keep(ocaml_num);
+//!         let num_root = num_root.keep(ocaml_num);
 //!         let result = ocaml_funcs::twice(cr, num_root);
 //!         i64::from_ocaml(&result) as usize
 //!     })
@@ -297,17 +297,17 @@
 //! // the first parameter of the function.
 //! ocaml_export! {
 //!     // The first parameter is a name to which the GC frame handle will be bound to.
-//!     // The remaining parameters must have type `&OCamlRef<T>`, and the return
+//!     // The remaining parameters must have type `OCamlRef<T>`, and the return
 //!     // value `OCaml<T>`.
-//!     fn rust_twice(cr, num: &OCamlRef<OCamlInt>) -> OCaml<OCamlInt> {
+//!     fn rust_twice(cr, num: OCamlRef<OCamlInt>) -> OCaml<OCamlInt> {
 //!         let num: i64 = num.to_rust(cr);
 //!         unsafe { OCaml::of_i64_unchecked(num * 2) }
 //!     }
 //!
 //!     fn rust_increment_bytes(
 //!         cr,
-//!         bytes: &OCamlRef<OCamlBytes>,
-//!         first_n: &OCamlRef<OCamlInt>,
+//!         bytes: OCamlRef<OCamlBytes>,
+//!         first_n: OCamlRef<OCamlInt>,
 //!     ) -> OCaml<OCamlBytes> {
 //!         let first_n: i64 = first_n.to_rust(cr);
 //!         let first_n = first_n as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,7 @@
 //!             bytes1_root,    // OCamlRef<String>
 //!             // Immediate OCaml values, such as ints and books have an as_value_ref() method
 //!             // that can be used to simulate rooting.
-//!             ocaml_first_n.as_value_ref(), // OCamlRef<OCamlInt>
+//!             &ocaml_first_n, // OCamlRef<OCamlInt>
 //!         );
 //!
 //!         // Perform the conversion of the OCaml result value into a
@@ -238,7 +238,7 @@
 //!         let result2 = ocaml_funcs::increment_bytes(
 //!             cr,
 //!             bytes2_root,
-//!             ocaml_first_n.as_value_ref(),
+//!             &ocaml_first_n,
 //!         );
 //!
 //!         // The `FromOCaml` trait provides the `from_ocaml` method to convert from
@@ -369,3 +369,6 @@ pub mod internal {
 #[doc(hidden)]
 #[cfg(doctest)]
 pub mod compile_fail_tests;
+
+#[cfg(test)]
+mod compile_ok_tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,8 @@
 //! - Functions that were exported from the OCaml side with `Callback.register` have to be declared using the [`ocaml!`] macro.
 //! - Before the program exist, or once the OCaml runtime is not required anymore, it has to be de-initialized by calling the `shutdown()` method on the OCaml runtime handle.
 //!
+//! If an exception is raised by an OCaml function, a `panic!` will happen. OCaml functions that are meant to be called from Rust should return values of `Result.t` type to signal errors.
+//!
 //! ### Example
 //!
 //! ```rust,no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,7 @@ pub use crate::memory::OCamlRooted;
 pub use crate::mlvalues::{
     OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, RawOCaml,
 };
-pub use crate::runtime::{OCamlAllocToken, OCamlRuntime};
+pub use crate::runtime::OCamlRuntime;
 pub use crate::value::OCaml;
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@
 //!     // The first argument to the macro is a reference to an `OCamlRuntime`, followed by a
 //!     // list of "root variables" (more on this later). The last argument
 //!     // is the block of code that will run inside that frame.
-//!     ocaml_frame!(cr, (bytes1_root, bytes2_root, first_n_root), {
+//!     ocaml_frame!(cr, (bytes1_root, bytes2_root), {
 //!         // The `ToOCaml` trait provides the `to_ocaml` method to convert Rust
 //!         // values into OCaml values.
 //!         let ocaml_bytes1: OCaml<String> = bytes1.to_ocaml(cr);
@@ -216,7 +216,6 @@
 //!         // Such conversion doesn't require any allocation on the OCaml side, and doesn't
 //!         // invalidate other `OCaml<T>` values.
 //!         let ocaml_first_n = unsafe { OCaml::of_i64_unchecked(first_n as i64) };
-//!         let first_n_root = &first_n_root.keep(ocaml_first_n);
 //!
 //!         // Any OCaml function (declared above in a `ocaml!` block) can be called as a regular
 //!         // Rust function, by passing a `&mut OCamlRuntime` as the first argument, followed by
@@ -225,7 +224,9 @@
 //!         let result1 = ocaml_funcs::increment_bytes(
 //!             cr,             // &mut OCamlRuntime
 //!             bytes1_root,    // &OCamlRoot<String>
-//!             first_n_root,   // &OCamlRoot<OCamlInt>
+//!             // Immediate OCaml values, such as ints and books have an as_root() method
+//!             // that can be used to simulate rooting.
+//!             &ocaml_first_n.as_root(), // &OCamlRoot<OCamlInt>
 //!         );
 //!
 //!         // Perform the conversion of the OCaml result value into a
@@ -237,7 +238,7 @@
 //!         let result2 = ocaml_funcs::increment_bytes(
 //!             cr,
 //!             bytes2_root,
-//!             first_n_root,
+//!             &ocaml_first_n.as_root(),
 //!         );
 //!
 //!         // The `FromOCaml` trait provides the `from_ocaml` method to convert from

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,13 @@
 //! - [How does it work](#how-does-it-work)
 //! - [Usage](#usage)
 //!   * [Rules](#rules)
-//!     + [Rule 1: The OCaml runtime handle and call macros](#rule-1-the-ocaml-runtime-handle-and-call-macros)
+//!     + [Rule 1: The OCaml runtime handle](#rule-1-the-ocaml-runtime-handle)
 //!     + [Rule 2: Liveness of OCaml values and rooting](#rule-2-liveness-of-ocaml-values-and-rooting)
 //!     + [Rule 3: Liveness and scope of rooted OCaml values](#rule-3-liveness-and-scope-of-rooted-ocaml-values)
 //!   * [Converting between OCaml and Rust data](#converting-between-ocaml-and-rust-data)
 //!     + [`FromOCaml` trait](#fromocaml-trait)
 //!     + [`ToOCaml` trait](#toocaml-trait)
+//!   * [Calling convention](#calling-convention)
 //!   * [Calling into OCaml from Rust](#calling-into-ocaml-from-rust)
 //!   * [Calling into Rust from OCaml](#calling-into-rust-from-ocaml)
 //! - [References and links](#references-and-links)
@@ -32,76 +33,18 @@
 //!
 //! There are a few rules that have to be followed when calling into the OCaml runtime:
 //!
-//! #### Rule 1: The OCaml runtime handle and call macros
+//! #### Rule 1: The OCaml runtime handle
 //!
-//! To interact with the OCaml runtime handle (be it reading, mutating or allocating values, or to call functions) a reference to the OCaml runtime handle must be available.
-//! When calling OCaml functions the handle must be passed as the first argument, and the call must be wrapped with one of the special call macros:
-//!
-//! - `ocaml_call!` when calling an OCaml function.
-//! - `ocaml_alloc!` when calling an OCaml value allocator function.
-//!
-//! Example:
-//!
-//! Without the macros, this error is produced, because without the macros an incorrect token is passed as the first argument:
-//!
-//! ```text,no_run
-//! error[E0308]: mismatched types
-//!   --> example.rs
-//!    |
-//!    |  let result = ocaml_function(cr, arg1, ..., argN);
-//!    |                              ^^ expected struct `OCamlAllocToken`, found `&mut OCamlRuntime<'_>`
-//! ```
+//! To interact with the OCaml runtime (be it reading, mutating or allocating values, or to call functions) a reference to the OCaml runtime handle must be available.
+//! Any function that interacts with the OCaml runtime takes as a first argument a reference to the OCaml runtime handle.
 //!
 //! #### Rule 2: Liveness of OCaml values and rooting
 //!
-//! OCaml values become stale after calls into the OCaml runtime and cannot be used again. This is enforced by Rust's borrow checker.
+//! Rust references to OCaml values become stale after calls into the OCaml runtime and cannot be used again. This is enforced by Rust's borrow checker.
 //!
 //! To have OCaml values survive across calls into the OCaml runtime, they have to be rooted.
 //!
 //! Rooting is only possible inside `ocaml_frame!` blocks, which initialize a list of root variables that can be used to root OCaml values.
-//!
-//! Example:
-//!
-//! ```text,no_run
-//! # use ocaml_interop::*;
-//! # ocaml! {
-//! #     fn ocaml_function(arg1: String) -> String;
-//! #     fn another_ocaml_function(arg: String);
-//! # }
-//! # let a_string = "string";
-//! # let arg1 = "arg1";
-//! # let arg2 = "arg2";
-//! # let cr = unsafe { &mut OCamlRuntime::recover_handle() };
-//! ocaml_frame!(cr, (result_root), {
-//!     let arg1 = arg1.to_ocaml(cr);
-//!     let result = ocaml_function(cr, arg1, /* ..., argN */);
-//!     let rooted_result = &result_root.keep(result);
-//!     let arg2 = ocaml_alloc!(arg2.to_ocaml(cr));
-//!     let another_result = ocaml_function(cr, arg2, /* ..., argN */);
-//!     // ...
-//!     let more_results = another_ocaml_function(cr, rooted_result);
-//!     // ...
-//! })
-//! ```
-//!
-//! If the value is not kept with `root_var.keep`, and instead an attempt is made to re-use it directly, Rust's borrow checker will complain:
-//!
-//! ```text,no_run
-//! error[E0502]: cannot borrow `*cr` as mutable because it is also borrowed as immutable
-//!   --> example.rs
-//!    |
-//!    |  let result = ocaml_call!(ocaml_function(cr, arg1, ..., argN)).unwrap();
-//!    |               ------------------------------------ immutable borrow occurs here
-//! ...
-//!    |  let another_result = ocaml_call!(ocaml_function(cr, arg1, ..., argN)).unwrap();
-//!    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
-//! ...
-//!    |  let more_results = ocaml_call!(another_ocaml_function(cr, result)).unwrap();
-//!    |                                                            ------ immutable borrow later used here
-//!    |
-//! ```
-//!
-//! There is no need to keep values that are used immediately without any calls into the OCaml runtime in-between their allocation and use.
 //!
 //! #### Rule 3: Liveness and scope of rooted OCaml values
 //!
@@ -119,9 +62,9 @@
 //! # let arg1 = "arg1";
 //! # let cr = unsafe { &mut OCamlRuntime::recover_handle() };
 //! let escape = ocaml_frame!(cr, (arg1_root), {
-//!     let arg1 = ocaml_alloc!(arg1.to_ocaml(cr));
-//!     let arg1_rooted = arg1_root.keep(arg1);
-//!     let result = ocaml_call!(ocaml_function(cr, cr.get(&arg1_rooted), /* ..., argN */)).unwrap();
+//!     let arg1 = arg1.to_ocaml(cr);
+//!     let arg1_rooted = &arg1_root.keep(arg1);
+//!     let result = ocaml_function(cr, arg1_rooted, /* ..., argN */);
 //!     let s: String = result.to_rust();
 //!     // ...
 //!     arg1_rooted
@@ -132,15 +75,15 @@
 //!
 //! ```text,no_run
 //! error[E0716]: temporary value dropped while borrowed
-//!   --> example.rs
+//!   --> src/lib.rs:64:14
 //!    |
 //!    |   let escape = ocaml_frame!(cr, (arg1_root), {
 //!    |  _____------___^
 //!    | |     |
 //!    | |     borrow later stored here
-//!    | |     let arg1 = ocaml_alloc!(arg1.to_ocaml(cr));
-//!    | |     let arg1_rooted = arg1_root.keep(arg1);
-//!    | |     let result = ocaml_call!(ocaml_function(cr, cr.get(&arg1_rooted), /* ..., argN */)).unwrap();
+//!    | |     let arg1 = arg1.to_ocaml(cr);
+//!    | |     let arg1_rooted = &arg1_root.keep(arg1);
+//!    | |     let result = ocaml_function(cr, arg1_rooted, /* ..., argN */);
 //! ...  |
 //!    | |     arg1_rooted
 //!    | | });
@@ -164,9 +107,23 @@
 //!
 //! #### [`ToOCaml`] trait
 //!
-//! The [`ToOCaml`] trait implements conversion from Rust values into OCaml values, using the `to_ocaml` method. `to_ocaml` can only be called when wrapped by the [`ocaml_alloc!`] macro form, and it takes a single parameter that must be a handle to the current GC frame.
+//! The [`ToOCaml`] trait implements conversion from Rust values into OCaml values, using the `to_ocaml` method. It takes a single parameter that must be a `&mut OCamlRuntime`.
 //!
-//! A more convenient way to convert Rust values into OCaml values is provided by the [`to_ocaml!`] macro.
+//! A more convenient way to convert Rust values into OCaml values is provided by the [`to_ocaml!`] macro that accepts a root variable as an optional third argument to return a value that is rooted already.
+//!
+//! ### Calling convention
+//!
+//! There are two possible calling conventions in regards to rooting, one with *callee rooted arguments*, and another with *caller rooted arguments*.
+//!
+//! #### Callee rooted arguments calling convention
+//!
+//! With this calling convention, values that are arguments to a function call are passed directly. Functions that receive arguments are responsible for rooting them. This is how OCaml's C API and `ocaml-interop` versions before `0.5.0` work.
+//!
+//! #### Caller rooted arguments calling convention
+//!
+//! With this calling convention, values that are arguments to a function call must be rooted by the caller. Then instead of the value, it is the root pointing to it is passed as an argument. This is how `ocaml-interop` works starting with version `0.5.0`.
+//!
+//! When a Rust function is called from OCaml, it will receive arguments as `&OCamlRooted<T>` values, and when a OCaml function is called from Rust, arguments will be passed as `&OCamlRooted<T>` values.
 //!
 //! ### Calling into OCaml from Rust
 //!
@@ -192,12 +149,9 @@
 //!
 //! - The OCaml runtime has to be initialized. If the driving program is a Rust application, it has to be done explicitly by doing `let runtime = OCamlRuntime::init()`, but if the driving program is an OCaml application, this is not required.
 //! - Functions that were exported from the OCaml side with `Callback.register` have to be declared using the [`ocaml!`] macro.
-//! - Blocks of code that call OCaml functions, or allocate OCaml values, must be wrapped by the [`ocaml_frame!`] macro.
-//! - Calls to functions that allocate OCaml values must be wrapped by the [`ocaml_alloc!`] macro. These always return a value and cannot signal failure.
-//! - Calls to functions exported by OCaml with `Callback.register` must be wrapped by the [`ocaml_call!`] macro. These return a value of type `Result<OCaml<T>, ocaml_interop::Error>`, with the error being returned to signal that an exception was raised by the called OCaml code.
 //! - Before the program exist, or once the OCaml runtime is not required anymore, it has to be de-initialized by calling the `shutdown()` method on the OCaml runtime handle.
 //!
-//! #### Example
+//! ### Example
 //!
 //! ```rust,no_run
 //! use ocaml_interop::{
@@ -216,72 +170,65 @@
 //!         // registered with `Callback.register "twice" twice`
 //!         pub fn twice(num: OCamlInt) -> OCamlInt;
 //!     }
-//!
-//!     // The two OCaml functions declared above can now be invoked with the
-//!     // `ocaml_call!` macro: `ocaml_call!(func_name(cr, args...))`.
-//!     // Note the first `cr` parameter, it is an OCaml Runtime handle.
 //! }
 //!
-//! fn increment_bytes(cr: &mut OCamlRuntime, bytes1: String, bytes2: String, first_n: usize) -> (String, String) {
+//! fn increment_bytes(
+//!     cr: &mut OCamlRuntime,
+//!     bytes1: String,
+//!     bytes2: String,
+//!     first_n: usize,
+//! ) -> (String, String) {
 //!     // Any calls into the OCaml runtime takes as input a `&mut` reference to an `OCamlRuntime`
 //!     // value that is obtained as the result of initializing the OCaml runtime.
 //!     // If rooting of OCaml values is needed, a new frame has to be opened by using the
 //!     // `ocaml_frame!` macro.
-//!     // The first argument to the macro is a reference to an OCamlRuntime, followed by an optional
+//!     // The first argument to the macro is a reference to an `OCamlRuntime`, followed by a
 //!     // list of "root variables" (more on this later). The last argument
 //!     // is the block of code that will run inside that frame.
 //!     ocaml_frame!(cr, (bytes1_root, bytes2_root, first_n_root), {
 //!         // The `ToOCaml` trait provides the `to_ocaml` method to convert Rust
-//!         // values into OCaml values. Because such conversions usually require
-//!         // the OCaml runtime to perform an allocation, calls to `to_ocaml` have
-//!         // to be wrapped by the `ocaml_alloc!` macro. A shorter version uses
-//!         // the `to_ocaml!` macro.
-//!         let ocaml_bytes1: OCaml<String> = to_ocaml!(cr, bytes1);
+//!         // values into OCaml values.
+//!         let ocaml_bytes1: OCaml<String> = bytes1.to_ocaml(cr);
 //!
 //!         // `ocaml_bytes1` is going to be referenced later, but there calls into the
 //!         // OCaml runtime that perform allocations happening before this value is used again.
 //!         // Those calls into the OCaml runtime invalidate this reference, so it has to be
 //!         // kept alive somehow. To do so, `bytes1_root.keep(ocaml_bytes1)` is used.
-//!         // `bytes1_root` is one of the "root variables" that were declared when opening this frame.
+//!         // `bytes1_root` is one of the "root variables" that were declared when opening
+//!         // this frame.
 //!         // Each "root variable" reserves space for a reference that will be tracked by the GC.
 //!         // A root variable's `root_var.keep(value)` method returns
 //!         // a rooted OCaml value that is going to be valid during the scope of
 //!         // the current `ocaml_frame!` block. Later `cr.get(rooted_value)` can be used
-//!         // to obtain the original OCaml value.
+//!         // to recover the original OCaml value.
 //!         let bytes1_rooted: &OCamlRooted<String> = &bytes1_root.keep(ocaml_bytes1);
 //!
-//!         // Same as above. Note that if we waited to perform this conversion
-//!         // until after `ocaml_bytes1` is used, no references would have to be
-//!         // kept for either of the two OCaml values, because they would be
-//!         // used immediately, with no allocations being performed by the
-//!         // OCaml runtime in-between.
-//!         // Here a third argument is passed to `to_ocaml!`, a root variable.
+//!         // Same as above. Here the convenience macro [`to_ocaml!`] is used.
+//!         // It works like `value.to_ocaml(cr)`, but has an optional third argument that
+//!         // can be a root variable to perform the rooting.
 //!         // This variation returns an `OCamlRooted` value instead of an `OCaml` one.
 //!         let bytes2_rooted = &to_ocaml!(cr, bytes2, bytes2_root);
 //!
-//!         // Rust `i64` integers can be converted into OCaml fixnums with `OCaml::of_i64` and `OCaml::of_i64_unchecked`.
-//!         // Such conversion doesn't require any allocation on the OCaml side,
-//!         // so this call doesn't have to be wrapped by `ocaml_alloc!` or `to_ocaml!`,
-//!         // and no GC handle is passed as an argument.
+//!         // Rust `i64` integers can be converted into OCaml fixnums with `OCaml::of_i64`
+//!         // and `OCaml::of_i64_unchecked`.
+//!         // Such conversion doesn't require any allocation on the OCaml side, and doesn't
+//!         // invalidate other `OCaml<T>` values.
 //!         let ocaml_first_n = unsafe { OCaml::of_i64_unchecked(first_n as i64) };
 //!         let first_n_rooted = &first_n_root.keep(ocaml_first_n);
 //!
-//!         // To call an OCaml function (declared above in a `ocaml!` block) the
-//!         // `ocaml_call!` macro is used. The GC handle has to be passed as the first argument,
-//!         // before all the other declared arguments.
-//!         // The result of this call is a Result<OCaml<T>, ocaml_interop::Error>, with `Err(...)`
-//!         // being the result of calls for which the OCaml runtime raises an exception.
+//!         // Any OCaml function (declared above in a `ocaml!` block) can be called as a regular
+//!         // Rust function, by passing a `&mut OCamlRuntime` as the first argument, followed by
+//!         // the rest of the arguments declared for that function.
+//!         // Arguments to these functions must be references to rooted values: `&OCamlRooted<T>`
 //!         let result1 = ocaml_funcs::increment_bytes(
-//!             cr,
-//!             // The reference created above is used here to obtain the value
-//!             // of `ocaml_bytes1`
-//!             bytes1_rooted,
-//!             first_n_rooted,
+//!             cr,             // &mut OCamlRuntime
+//!             bytes1_rooted,  // &OCamlRooted<String>
+//!             first_n_rooted, // &OCamlRooted<OCamlInt>
 //!         );
 //!
 //!         // Perform the conversion of the OCaml result value into a
 //!         // Rust value while the reference is still valid because the
-//!         // `ocaml_call!` that follows will invalidate it.
+//!         // call that follows will invalidate it.
 //!         // Alternatively, the result of `rootvar.keep(result1)` could be used
 //!         // to be able to reference the value later through an `OCamlRooted` value.
 //!         let new_bytes1: String = result1.to_rust();
@@ -336,7 +283,10 @@
 //! #### Example
 //!
 //! ```rust,no_run
-//! use ocaml_interop::{to_ocaml, ocaml_export, ocaml_frame, FromOCaml, OCamlInt, OCaml, OCamlBytes, OCamlRooted, ToOCaml};
+//! use ocaml_interop::{
+//!     to_ocaml, ocaml_export, ocaml_frame, FromOCaml, OCamlInt, OCaml, OCamlBytes,
+//!     OCamlRooted, ToOCaml,
+//! };
 //!
 //! // `ocaml_export` expands the function definitions by adding `pub` visibility and
 //! // the required `#[no_mangle]` and `extern` declarations. It also takes care of
@@ -344,13 +294,18 @@
 //! // the first parameter of the function.
 //! ocaml_export! {
 //!     // The first parameter is a name to which the GC frame handle will be bound to.
-//!     // The remaining parameters and return value must have a declared type of `OCaml<T>`.
+//!     // The remaining parameters must have type `&OCamlRooted<T>`, and the return
+//!     // value `OCaml<T>`.
 //!     fn rust_twice(cr, num: &OCamlRooted<OCamlInt>) -> OCaml<OCamlInt> {
 //!         let num: i64 = num.to_rust(cr);
 //!         unsafe { OCaml::of_i64_unchecked(num * 2) }
 //!     }
 //!
-//!     fn rust_increment_bytes(cr, bytes: &OCamlRooted<OCamlBytes>, first_n: &OCamlRooted<OCamlInt>) -> OCaml<OCamlBytes> {
+//!     fn rust_increment_bytes(
+//!         cr,
+//!         bytes: &OCamlRooted<OCamlBytes>,
+//!         first_n: &OCamlRooted<OCamlInt>,
+//!     ) -> OCaml<OCamlBytes> {
 //!         let first_n: i64 = first_n.to_rust(cr);
 //!         let first_n = first_n as usize;
 //!         let mut vec: Vec<u8> = bytes.to_rust(cr);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -89,7 +89,7 @@ macro_rules! ocaml {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
             $arg: &$crate::OCamlRooted<$typ>,
-        ) -> Result<$crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)>, $crate::OCamlError> {
+        ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(F, $name);
             F.call(cr, $arg)
         }
@@ -105,7 +105,7 @@ macro_rules! ocaml {
             cr: &'a mut $crate::OCamlRuntime,
             $arg1: &$crate::OCamlRooted<$typ1>,
             $arg2: &$crate::OCamlRooted<$typ2>,
-        ) -> Result<$crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)>, $crate::OCamlError> {
+        ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(F, $name);
             F.call2(cr, $arg1, $arg2)
         }
@@ -123,7 +123,7 @@ macro_rules! ocaml {
             $arg1: &$crate::OCamlRooted<$typ1>,
             $arg2: &$crate::OCamlRooted<$typ2>,
             $arg3: &$crate::OCamlRooted<$typ3>,
-        ) -> Result<$crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)>, $crate::OCamlError> {
+        ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(F, $name);
             F.call3(cr, $arg1, $arg2, $arg3)
         }
@@ -137,7 +137,7 @@ macro_rules! ocaml {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
             $($arg: &$crate::OCamlRooted<$typ>),+
-    ) -> Result<$crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)>, $crate::OCamlError> {
+    ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(F, $name);
             F.call_n(cr, &mut [$($arg.get_raw()),+])
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -553,7 +553,7 @@ macro_rules! impl_from_ocaml_record {
         $($field:ident : $ocaml_field_typ:ty),+ $(,)?
     }) => {
         unsafe impl $crate::FromOCaml<$ocaml_typ> for $rust_typ {
-            fn from_ocaml(v: $crate::OCaml<$ocaml_typ>) -> Self {
+            fn from_ocaml(v: &$crate::OCaml<$ocaml_typ>) -> Self {
                 $crate::ocaml_unpack_record! { v =>
                     $rust_typ {
                         $($field : $ocaml_field_typ),+
@@ -678,7 +678,7 @@ macro_rules! impl_from_ocaml_variant {
         $($t:tt)*
     }) => {
         unsafe impl $crate::FromOCaml<$ocaml_typ> for $rust_typ {
-            fn from_ocaml(v: $crate::OCaml<$ocaml_typ>) -> Self {
+            fn from_ocaml(v: &$crate::OCaml<$ocaml_typ>) -> Self {
                 let result = $crate::ocaml_unpack_variant! {
                     v => {
                         $($t)*
@@ -926,7 +926,7 @@ macro_rules! impl_from_ocaml_polymorphic_variant {
         $($t:tt)*
     }) => {
         unsafe impl $crate::FromOCaml<$ocaml_typ> for $rust_typ {
-            fn from_ocaml(v: $crate::OCaml<$ocaml_typ>) -> Self {
+            fn from_ocaml(v: &$crate::OCaml<$ocaml_typ>) -> Self {
                 let result = $crate::ocaml_unpack_polymorphic_variant! {
                     v => {
                         $($t)*

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -396,7 +396,7 @@ macro_rules! impl_conv_ocaml_variant {
 /// // NOTE: What is important is the order of the fields, not their names.
 ///
 /// # fn unpack_record_example(cr: &mut OCamlRuntime) {
-/// let ocaml_struct = make_mystruct(cr, OCamlRef::unit());
+/// let ocaml_struct = make_mystruct(cr, &OCaml::unit());
 /// let my_struct = ocaml_unpack_record! {
 ///     //  value    => RustConstructor { field: OCamlType, ... }
 ///     ocaml_struct => MyStruct {
@@ -737,7 +737,7 @@ macro_rules! impl_from_ocaml_variant {
 /// // NOTE: What is important is the order of the tags, not their names.
 ///
 /// # fn unpack_variant_example(cr: &mut OCamlRuntime) {
-/// let ocaml_variant = make_ocaml_movement(cr, OCamlRef::unit());
+/// let ocaml_variant = make_ocaml_movement(cr, &OCaml::unit());
 /// let result = ocaml_unpack_variant! {
 ///     ocaml_variant => {
 ///         // Alternative: StepLeft  => Movement::StepLeft
@@ -982,7 +982,7 @@ macro_rules! impl_from_ocaml_polymorphic_variant {
 /// //      ]
 ///
 /// # fn unpack_polymorphic_variant_example(cr: &mut OCamlRuntime) {
-/// let ocaml_polymorphic_variant = make_ocaml_polymorphic_movement(cr, OCamlRef::unit());
+/// let ocaml_polymorphic_variant = make_ocaml_polymorphic_movement(cr, &OCaml::unit());
 /// let result = ocaml_unpack_polymorphic_variant! {
 ///     ocaml_polymorphic_variant => {
 ///         StepLeft  => Movement::StepLeft,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -60,6 +60,8 @@ macro_rules! ocaml_frame {
 ///
 /// The return value is an `OCaml<RetType>`.
 ///
+/// Calls that raise an OCaml exception will `panic!`.
+///
 /// # Examples
 ///
 /// ```

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -138,7 +138,7 @@ macro_rules! ocaml {
             $($arg: $crate::OCamlRef<$typ>),+
     ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
-            closure.call_n(cr, &mut [$($arg.get_raw()),+])
+            closure.call_n(cr, &mut [$(unsafe { $arg.get_raw() }),+])
         }
 
         $crate::ocaml!($($t)*);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -555,7 +555,7 @@ macro_rules! impl_from_ocaml_record {
         $($field:ident : $ocaml_field_typ:ty),+ $(,)?
     }) => {
         unsafe impl $crate::FromOCaml<$ocaml_typ> for $rust_typ {
-            fn from_ocaml(v: &$crate::OCaml<$ocaml_typ>) -> Self {
+            fn from_ocaml(v: $crate::OCaml<$ocaml_typ>) -> Self {
                 $crate::ocaml_unpack_record! { v =>
                     $rust_typ {
                         $($field : $ocaml_field_typ),+
@@ -680,7 +680,7 @@ macro_rules! impl_from_ocaml_variant {
         $($t:tt)*
     }) => {
         unsafe impl $crate::FromOCaml<$ocaml_typ> for $rust_typ {
-            fn from_ocaml(v: &$crate::OCaml<$ocaml_typ>) -> Self {
+            fn from_ocaml(v: $crate::OCaml<$ocaml_typ>) -> Self {
                 let result = $crate::ocaml_unpack_variant! {
                     v => {
                         $($t)*
@@ -928,7 +928,7 @@ macro_rules! impl_from_ocaml_polymorphic_variant {
         $($t:tt)*
     }) => {
         unsafe impl $crate::FromOCaml<$ocaml_typ> for $rust_typ {
-            fn from_ocaml(v: &$crate::OCaml<$ocaml_typ>) -> Self {
+            fn from_ocaml(v: $crate::OCaml<$ocaml_typ>) -> Self {
                 let result = $crate::ocaml_unpack_polymorphic_variant! {
                     v => {
                         $($t)*

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,11 +26,8 @@ use crate::*;
 ///     ocaml_frame!(cr, (hello_ocaml, bye_ocaml), {
 ///         let hello_ocaml = &to_ocaml!(cr, "hello OCaml!", hello_ocaml);
 ///         let bye_ocaml = &to_ocaml!(cr, "bye OCaml!", bye_ocaml);
-///         ocaml_call!(print_endline(cr, cr.get(hello_ocaml)));
-///         ocaml_call!(print_endline(cr, cr.get(bye_ocaml)));
-///         // Values that don't need to be kept across calls can be used directly
-///         let immediate_use = to_ocaml!(cr, "no need to `keep` me");
-///         ocaml_call!(print_endline(cr, immediate_use));
+///         print_endline(cr, hello_ocaml);
+///         print_endline(cr, bye_ocaml);
 ///     });
 /// # }
 /// ```
@@ -170,7 +167,7 @@ macro_rules! ocaml {
 ///     fn rust_twice_boxed_i32(cr, num: &OCamlRooted<OCamlInt32>) -> OCaml<OCamlInt32> {
 ///         let num: i32 = num.to_rust(cr);
 ///         let result = num * 2;
-///         ocaml_alloc!(result.to_ocaml(cr))
+///         result.to_ocaml(cr)
 ///     }
 ///
 ///     fn rust_add_unboxed_floats_noalloc(_cr, num: f64, num2: f64) -> f64 {
@@ -180,7 +177,7 @@ macro_rules! ocaml {
 ///     fn rust_twice_boxed_float(cr, num: &OCamlRooted<OCamlFloat>) -> OCaml<OCamlFloat> {
 ///         let num: f64 = num.to_rust(cr);
 ///         let result = num * 2.0;
-///         ocaml_alloc!(result.to_ocaml(cr))
+///         result.to_ocaml(cr)
 ///     }
 ///
 ///     fn rust_increment_ints_list(cr, ints: &OCamlRooted<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
@@ -190,14 +187,14 @@ macro_rules! ocaml {
 ///             vec[i] += 1;
 ///         }
 ///
-///         ocaml_alloc!(vec.to_ocaml(cr))
+///         vec.to_ocaml(cr)
 ///     }
 ///
 ///     fn rust_make_tuple(cr, fst: &OCamlRooted<String>, snd: &OCamlRooted<OCamlInt>) -> OCaml<(String, OCamlInt)> {
 ///         let fst: String = fst.to_rust(cr);
 ///         let snd: i64 = snd.to_rust(cr);
 ///         let tuple = (fst, snd);
-///         ocaml_alloc!(tuple.to_ocaml(cr))
+///         tuple.to_ocaml(cr)
 ///     }
 /// }
 /// ```
@@ -397,7 +394,7 @@ macro_rules! impl_conv_ocaml_variant {
 /// // NOTE: What is important is the order of the fields, not their names.
 ///
 /// # fn unpack_record_example(cr: &mut OCamlRuntime) {
-/// let ocaml_struct = ocaml_call!(make_mystruct(cr, OCaml::unit())).unwrap();
+/// let ocaml_struct = make_mystruct(cr, &OCamlRooted::unit());
 /// let my_struct = ocaml_unpack_record! {
 ///     //  value    => RustConstructor { field: OCamlType, ... }
 ///     ocaml_struct => MyStruct {
@@ -481,7 +478,7 @@ macro_rules! ocaml_alloc_tagged_block {
 ///
 /// # fn alloc_record_example(cr: &mut OCamlRuntime) {
 /// let ms = MyStruct { int_field: 132, string_field: "blah".to_owned() };
-/// let ocaml_ms: OCamlAllocResult<MyStruct> = ocaml_alloc_record! {
+/// let ocaml_ms: OCaml<MyStruct> = ocaml_alloc_record! {
 ///     //  value { field: OCamlType, ... }
 ///     cr, ms {  // cr: &mut OCamlRuntime
 ///         // optionally `=> expr` can be used to pre-process the field value
@@ -738,7 +735,7 @@ macro_rules! impl_from_ocaml_variant {
 /// // NOTE: What is important is the order of the tags, not their names.
 ///
 /// # fn unpack_variant_example(cr: &mut OCamlRuntime) {
-/// let ocaml_variant = ocaml_call!(make_ocaml_movement(cr, OCaml::unit())).unwrap();
+/// let ocaml_variant = make_ocaml_movement(cr, &OCamlRooted::unit());
 /// let result = ocaml_unpack_variant! {
 ///     ocaml_variant => {
 ///         // Alternative: StepLeft  => Movement::StepLeft
@@ -799,7 +796,7 @@ macro_rules! ocaml_unpack_variant {
 ///
 /// # fn alloc_variant_example(cr: &mut OCamlRuntime) {
 /// let movement = Movement::Rotate(180.0);
-/// let ocaml_movement: OCamlAllocResult<Movement> = ocaml_alloc_variant! {
+/// let ocaml_movement: OCaml<Movement> = ocaml_alloc_variant! {
 ///     cr, movement => {
 ///         Movement::StepLeft,
 ///         Movement::StepRight,
@@ -983,7 +980,7 @@ macro_rules! impl_from_ocaml_polymorphic_variant {
 /// //      ]
 ///
 /// # fn unpack_polymorphic_variant_example(cr: &mut OCamlRuntime) {
-/// let ocaml_polymorphic_variant = ocaml_call!(make_ocaml_polymorphic_movement(cr, OCaml::unit())).unwrap();
+/// let ocaml_polymorphic_variant = make_ocaml_polymorphic_movement(cr, &OCamlRooted::unit());
 /// let result = ocaml_unpack_polymorphic_variant! {
 ///     ocaml_polymorphic_variant => {
 ///         StepLeft  => Movement::StepLeft,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -35,7 +35,7 @@ use crate::*;
 macro_rules! ocaml_frame {
    ($cr:ident, ($($rootvar:ident),+ $(,)?), $body:block) => {{
         let mut frame = $cr.open_frame();
-        let local_roots = $crate::repeat_slice!(::core::cell::Cell::new($crate::internal::UNIT), $($rootvar)+);
+        let local_roots = $crate::repeat_slice!(::core::cell::UnsafeCell::new($crate::internal::UNIT), $($rootvar)+);
         let gc = frame.initialize(&local_roots);
         $(
             let $rootvar = unsafe { &mut $crate::internal::OCamlRawRoot::reserve(gc) };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -24,8 +24,8 @@ use crate::*;
 /// # }
 /// # fn ocaml_frame_macro_example(cr: &mut OCamlRuntime) {
 ///     ocaml_frame!(cr, (hello_ocaml, bye_ocaml), {
-///         let hello_ocaml = &to_ocaml!(cr, "hello OCaml!", hello_ocaml);
-///         let bye_ocaml = &to_ocaml!(cr, "bye OCaml!", bye_ocaml);
+///         let hello_ocaml = to_ocaml!(cr, "hello OCaml!", hello_ocaml);
+///         let bye_ocaml = to_ocaml!(cr, "bye OCaml!", bye_ocaml);
 ///         print_endline(cr, hello_ocaml);
 ///         print_endline(cr, bye_ocaml);
 ///     });
@@ -56,7 +56,7 @@ macro_rules! ocaml_frame {
 /// Visibility and return value type can be omitted. The return type defaults to unit when omitted.
 ///
 /// When invoking one of these functions, the first argument must be a `&mut OCamlRuntime`,
-/// and the remaining arguments `&OCamlRef<ArgT>`.
+/// and the remaining arguments `OCamlRef<ArgT>`.
 ///
 /// The return value is an `OCaml<RetType>`.
 ///
@@ -87,7 +87,7 @@ macro_rules! ocaml {
     ) $(-> $rtyp:ty)?; $($t:tt)*) => {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
-            $arg: &$crate::OCamlRef<$typ>,
+            $arg: $crate::OCamlRef<$typ>,
         ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
             closure.call(cr, $arg)
@@ -102,8 +102,8 @@ macro_rules! ocaml {
     ) $(-> $rtyp:ty)?; $($t:tt)*) => {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
-            $arg1: &$crate::OCamlRef<$typ1>,
-            $arg2: &$crate::OCamlRef<$typ2>,
+            $arg1: $crate::OCamlRef<$typ1>,
+            $arg2: $crate::OCamlRef<$typ2>,
         ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
             closure.call2(cr, $arg1, $arg2)
@@ -119,9 +119,9 @@ macro_rules! ocaml {
     ) $(-> $rtyp:ty)?; $($t:tt)*) => {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
-            $arg1: &$crate::OCamlRef<$typ1>,
-            $arg2: &$crate::OCamlRef<$typ2>,
-            $arg3: &$crate::OCamlRef<$typ3>,
+            $arg1: $crate::OCamlRef<$typ1>,
+            $arg2: $crate::OCamlRef<$typ2>,
+            $arg3: $crate::OCamlRef<$typ3>,
         ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
             closure.call3(cr, $arg1, $arg2, $arg3)
@@ -135,7 +135,7 @@ macro_rules! ocaml {
     ) $(-> $rtyp:ty)?; $($t:tt)*) => {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
-            $($arg: &$crate::OCamlRef<$typ>),+
+            $($arg: $crate::OCamlRef<$typ>),+
     ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
             closure.call_n(cr, &mut [$($arg.get_raw()),+])
@@ -161,12 +161,12 @@ macro_rules! ocaml {
 /// ```
 /// # use ocaml_interop::*;
 /// ocaml_export! {
-///     fn rust_twice(cr, num: &OCamlRef<OCamlInt>) -> OCaml<OCamlInt> {
+///     fn rust_twice(cr, num: OCamlRef<OCamlInt>) -> OCaml<OCamlInt> {
 ///         let num: i64 = num.to_rust(cr);
 ///         unsafe { OCaml::of_i64_unchecked(num * 2) }
 ///     }
 ///
-///     fn rust_twice_boxed_i32(cr, num: &OCamlRef<OCamlInt32>) -> OCaml<OCamlInt32> {
+///     fn rust_twice_boxed_i32(cr, num: OCamlRef<OCamlInt32>) -> OCaml<OCamlInt32> {
 ///         let num: i32 = num.to_rust(cr);
 ///         let result = num * 2;
 ///         result.to_ocaml(cr)
@@ -176,13 +176,13 @@ macro_rules! ocaml {
 ///         num * num2
 ///     }
 ///
-///     fn rust_twice_boxed_float(cr, num: &OCamlRef<OCamlFloat>) -> OCaml<OCamlFloat> {
+///     fn rust_twice_boxed_float(cr, num: OCamlRef<OCamlFloat>) -> OCaml<OCamlFloat> {
 ///         let num: f64 = num.to_rust(cr);
 ///         let result = num * 2.0;
 ///         result.to_ocaml(cr)
 ///     }
 ///
-///     fn rust_increment_ints_list(cr, ints: &OCamlRef<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
+///     fn rust_increment_ints_list(cr, ints: OCamlRef<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
 ///         let mut vec: Vec<i64> = ints.to_rust(cr);
 ///
 ///         for i in 0..vec.len() {
@@ -192,7 +192,7 @@ macro_rules! ocaml {
 ///         vec.to_ocaml(cr)
 ///     }
 ///
-///     fn rust_make_tuple(cr, fst: &OCamlRef<String>, snd: &OCamlRef<OCamlInt>) -> OCaml<(String, OCamlInt)> {
+///     fn rust_make_tuple(cr, fst: OCamlRef<String>, snd: OCamlRef<OCamlInt>) -> OCaml<(String, OCamlInt)> {
 ///         let fst: String = fst.to_rust(cr);
 ///         let snd: i64 = snd.to_rust(cr);
 ///         let tuple = (fst, snd);
@@ -285,7 +285,7 @@ macro_rules! ocaml_export {
 /// # use ocaml_interop::*;
 /// # fn to_ocaml_macro_example(cr: &mut OCamlRuntime) {
 ///     ocaml_frame!(cr, (rootvar), {
-///         let ocaml_string_ref: &OCamlRef<String> = &to_ocaml!(cr, "hello OCaml!", rootvar);
+///         let ocaml_string_ref: OCamlRef<String> = to_ocaml!(cr, "hello OCaml!", rootvar);
 ///         // ...
 ///         # ()
 ///     });
@@ -396,7 +396,7 @@ macro_rules! impl_conv_ocaml_variant {
 /// // NOTE: What is important is the order of the fields, not their names.
 ///
 /// # fn unpack_record_example(cr: &mut OCamlRuntime) {
-/// let ocaml_struct = make_mystruct(cr, &OCamlRef::unit());
+/// let ocaml_struct = make_mystruct(cr, OCamlRef::unit());
 /// let my_struct = ocaml_unpack_record! {
 ///     //  value    => RustConstructor { field: OCamlType, ... }
 ///     ocaml_struct => MyStruct {
@@ -737,7 +737,7 @@ macro_rules! impl_from_ocaml_variant {
 /// // NOTE: What is important is the order of the tags, not their names.
 ///
 /// # fn unpack_variant_example(cr: &mut OCamlRuntime) {
-/// let ocaml_variant = make_ocaml_movement(cr, &OCamlRef::unit());
+/// let ocaml_variant = make_ocaml_movement(cr, OCamlRef::unit());
 /// let result = ocaml_unpack_variant! {
 ///     ocaml_variant => {
 ///         // Alternative: StepLeft  => Movement::StepLeft
@@ -982,7 +982,7 @@ macro_rules! impl_from_ocaml_polymorphic_variant {
 /// //      ]
 ///
 /// # fn unpack_polymorphic_variant_example(cr: &mut OCamlRuntime) {
-/// let ocaml_polymorphic_variant = make_ocaml_polymorphic_movement(cr, &OCamlRef::unit());
+/// let ocaml_polymorphic_variant = make_ocaml_polymorphic_movement(cr, OCamlRef::unit());
 /// let result = ocaml_unpack_polymorphic_variant! {
 ///     ocaml_polymorphic_variant => {
 ///         StepLeft  => Movement::StepLeft,
@@ -1291,10 +1291,10 @@ macro_rules! expand_rooted_args_init {
 
     // Other values are wrapped in `OCamlRef<T>` as given the same lifetime as the OCaml runtime handle borrow.
     (($root:ident), $arg:ident : $typ:ty) =>
-        (let $arg : $typ = unsafe { &$root.keep_raw($arg) };);
+        (let $arg : $typ = unsafe { $root.keep_raw($arg) };);
 
     (($root:ident $($roots:ident)*), $arg:ident : $typ:ty, $($args:tt)*) => {
-        let $arg : $typ = unsafe { &$root.keep_raw($arg) };
+        let $arg : $typ = unsafe { $root.keep_raw($arg) };
         $crate::expand_rooted_args_init!(($($roots)*), $($args)*)
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -89,8 +89,8 @@ macro_rules! ocaml {
             cr: &'a mut $crate::OCamlRuntime,
             $arg: &$crate::OCamlRoot<$typ>,
         ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
-            $crate::ocaml_closure_reference!(F, $name);
-            F.call(cr, $arg)
+            $crate::ocaml_closure_reference!(closure, $name);
+            closure.call(cr, $arg)
         }
 
         $crate::ocaml!($($t)*);
@@ -105,8 +105,8 @@ macro_rules! ocaml {
             $arg1: &$crate::OCamlRoot<$typ1>,
             $arg2: &$crate::OCamlRoot<$typ2>,
         ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
-            $crate::ocaml_closure_reference!(F, $name);
-            F.call2(cr, $arg1, $arg2)
+            $crate::ocaml_closure_reference!(closure, $name);
+            closure.call2(cr, $arg1, $arg2)
         }
 
         $crate::ocaml!($($t)*);
@@ -123,8 +123,8 @@ macro_rules! ocaml {
             $arg2: &$crate::OCamlRoot<$typ2>,
             $arg3: &$crate::OCamlRoot<$typ3>,
         ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
-            $crate::ocaml_closure_reference!(F, $name);
-            F.call3(cr, $arg1, $arg2, $arg3)
+            $crate::ocaml_closure_reference!(closure, $name);
+            closure.call3(cr, $arg1, $arg2, $arg3)
         }
 
         $crate::ocaml!($($t)*);
@@ -137,8 +137,8 @@ macro_rules! ocaml {
             cr: &'a mut $crate::OCamlRuntime,
             $($arg: &$crate::OCamlRoot<$typ>),+
     ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
-            $crate::ocaml_closure_reference!(F, $name);
-            F.call_n(cr, &mut [$($arg.get_raw()),+])
+            $crate::ocaml_closure_reference!(closure, $name);
+            closure.call_n(cr, &mut [$($arg.get_raw()),+])
         }
 
         $crate::ocaml!($($t)*);
@@ -1230,14 +1230,14 @@ macro_rules! unpack_polymorphic_variant_tag {
 #[macro_export]
 macro_rules! ocaml_closure_reference {
     ($var:ident, $name:ident) => {
-        static name: &str = stringify!($name);
+        static NAME: &str = stringify!($name);
         static mut OC: Option<$crate::internal::OCamlClosure> = None;
         static INIT: ::std::sync::Once = ::std::sync::Once::new();
         let $var = unsafe {
             INIT.call_once(|| {
-                OC = $crate::internal::OCamlClosure::named(name);
+                OC = $crate::internal::OCamlClosure::named(NAME);
             });
-            OC.unwrap_or_else(|| panic!("OCaml closure with name '{}' not registered", name))
+            OC.unwrap_or_else(|| panic!("OCaml closure with name '{}' not registered", NAME))
         };
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,12 +9,12 @@ use crate::*;
 /// The first argument to this macro must a reference to an OCaml runtime handle.
 ///
 /// The second argument is a list of "root variables" to reserve. These variables can
-/// be used to "root" [`OCaml`] values to obtain [`OCamlRoot`] values that can be used
+/// be used to "root" [`OCaml`] values to obtain [`OCamlRef`] values that can be used
 /// to recover stale references to [`OCaml`] values after calls to the OCaml runtime.
 ///
 /// # Examples
 ///
-/// The following example reserves two root variables which are consumed to create two [`OCamlRoot`]
+/// The following example reserves two root variables which are consumed to create two [`OCamlRef`]
 /// values later used to retrieve two OCaml values after performing allocations through the OCaml runtime:
 ///
 /// ```
@@ -56,7 +56,7 @@ macro_rules! ocaml_frame {
 /// Visibility and return value type can be omitted. The return type defaults to unit when omitted.
 ///
 /// When invoking one of these functions, the first argument must be a `&mut OCamlRuntime`,
-/// and the remaining arguments `&OCamlRoot<ArgT>`.
+/// and the remaining arguments `&OCamlRef<ArgT>`.
 ///
 /// The return value is an `OCaml<RetType>`.
 ///
@@ -87,7 +87,7 @@ macro_rules! ocaml {
     ) $(-> $rtyp:ty)?; $($t:tt)*) => {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
-            $arg: &$crate::OCamlRoot<$typ>,
+            $arg: &$crate::OCamlRef<$typ>,
         ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
             closure.call(cr, $arg)
@@ -102,8 +102,8 @@ macro_rules! ocaml {
     ) $(-> $rtyp:ty)?; $($t:tt)*) => {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
-            $arg1: &$crate::OCamlRoot<$typ1>,
-            $arg2: &$crate::OCamlRoot<$typ2>,
+            $arg1: &$crate::OCamlRef<$typ1>,
+            $arg2: &$crate::OCamlRef<$typ2>,
         ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
             closure.call2(cr, $arg1, $arg2)
@@ -119,9 +119,9 @@ macro_rules! ocaml {
     ) $(-> $rtyp:ty)?; $($t:tt)*) => {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
-            $arg1: &$crate::OCamlRoot<$typ1>,
-            $arg2: &$crate::OCamlRoot<$typ2>,
-            $arg3: &$crate::OCamlRoot<$typ3>,
+            $arg1: &$crate::OCamlRef<$typ1>,
+            $arg2: &$crate::OCamlRef<$typ2>,
+            $arg3: &$crate::OCamlRef<$typ3>,
         ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
             closure.call3(cr, $arg1, $arg2, $arg3)
@@ -135,7 +135,7 @@ macro_rules! ocaml {
     ) $(-> $rtyp:ty)?; $($t:tt)*) => {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
-            $($arg: &$crate::OCamlRoot<$typ>),+
+            $($arg: &$crate::OCamlRef<$typ>),+
     ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
             closure.call_n(cr, &mut [$($arg.get_raw()),+])
@@ -161,12 +161,12 @@ macro_rules! ocaml {
 /// ```
 /// # use ocaml_interop::*;
 /// ocaml_export! {
-///     fn rust_twice(cr, num: &OCamlRoot<OCamlInt>) -> OCaml<OCamlInt> {
+///     fn rust_twice(cr, num: &OCamlRef<OCamlInt>) -> OCaml<OCamlInt> {
 ///         let num: i64 = num.to_rust(cr);
 ///         unsafe { OCaml::of_i64_unchecked(num * 2) }
 ///     }
 ///
-///     fn rust_twice_boxed_i32(cr, num: &OCamlRoot<OCamlInt32>) -> OCaml<OCamlInt32> {
+///     fn rust_twice_boxed_i32(cr, num: &OCamlRef<OCamlInt32>) -> OCaml<OCamlInt32> {
 ///         let num: i32 = num.to_rust(cr);
 ///         let result = num * 2;
 ///         result.to_ocaml(cr)
@@ -176,13 +176,13 @@ macro_rules! ocaml {
 ///         num * num2
 ///     }
 ///
-///     fn rust_twice_boxed_float(cr, num: &OCamlRoot<OCamlFloat>) -> OCaml<OCamlFloat> {
+///     fn rust_twice_boxed_float(cr, num: &OCamlRef<OCamlFloat>) -> OCaml<OCamlFloat> {
 ///         let num: f64 = num.to_rust(cr);
 ///         let result = num * 2.0;
 ///         result.to_ocaml(cr)
 ///     }
 ///
-///     fn rust_increment_ints_list(cr, ints: &OCamlRoot<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
+///     fn rust_increment_ints_list(cr, ints: &OCamlRef<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
 ///         let mut vec: Vec<i64> = ints.to_rust(cr);
 ///
 ///         for i in 0..vec.len() {
@@ -192,7 +192,7 @@ macro_rules! ocaml {
 ///         vec.to_ocaml(cr)
 ///     }
 ///
-///     fn rust_make_tuple(cr, fst: &OCamlRoot<String>, snd: &OCamlRoot<OCamlInt>) -> OCaml<(String, OCamlInt)> {
+///     fn rust_make_tuple(cr, fst: &OCamlRef<String>, snd: &OCamlRef<OCamlInt>) -> OCaml<(String, OCamlInt)> {
 ///         let fst: String = fst.to_rust(cr);
 ///         let snd: i64 = snd.to_rust(cr);
 ///         let tuple = (fst, snd);
@@ -266,7 +266,7 @@ macro_rules! ocaml_export {
 ///
 /// An alternative form accepts a third "root variable" argument: `to_ocaml!(cr, value, rootvar)`.
 /// `rootvar` is one of the "root variables" declared when opening an [`ocaml_frame!`].
-/// This variant consumes `rootvar` returns an [`OCamlRoot`] value instead of an [`OCaml`] one.
+/// This variant consumes `rootvar` returns an [`OCamlRef`] value instead of an [`OCaml`] one.
 ///
 /// # Examples
 ///
@@ -285,7 +285,7 @@ macro_rules! ocaml_export {
 /// # use ocaml_interop::*;
 /// # fn to_ocaml_macro_example(cr: &mut OCamlRuntime) {
 ///     ocaml_frame!(cr, (rootvar), {
-///         let ocaml_string_ref: &OCamlRoot<String> = &to_ocaml!(cr, "hello OCaml!", rootvar);
+///         let ocaml_string_ref: &OCamlRef<String> = &to_ocaml!(cr, "hello OCaml!", rootvar);
 ///         // ...
 ///         # ()
 ///     });
@@ -396,7 +396,7 @@ macro_rules! impl_conv_ocaml_variant {
 /// // NOTE: What is important is the order of the fields, not their names.
 ///
 /// # fn unpack_record_example(cr: &mut OCamlRuntime) {
-/// let ocaml_struct = make_mystruct(cr, &OCamlRoot::unit());
+/// let ocaml_struct = make_mystruct(cr, &OCamlRef::unit());
 /// let my_struct = ocaml_unpack_record! {
 ///     //  value    => RustConstructor { field: OCamlType, ... }
 ///     ocaml_struct => MyStruct {
@@ -440,7 +440,7 @@ macro_rules! ocaml_alloc_tagged_block {
             $crate::ocaml_frame!($cr, (block), {
                 let mut current = 0;
                 let field_count = $crate::count_fields!($($field)*);
-                let block: $crate::OCamlRoot<()> = block.keep_raw($crate::internal::caml_alloc(field_count, $tag));
+                let block: $crate::OCamlRef<()> = block.keep_raw($crate::internal::caml_alloc(field_count, $tag));
                 $(
                     let $field: $crate::OCaml<$ocaml_typ> = $crate::to_ocaml!($cr, $field);
                     $crate::internal::store_field(block.get_raw(), current, $field.raw());
@@ -504,7 +504,7 @@ macro_rules! ocaml_alloc_record {
             $crate::ocaml_frame!($cr, (record), {
                 let mut current = 0;
                 let field_count = $crate::count_fields!($($field)*);
-                let record: $crate::OCamlRoot<()> = record.keep_raw($crate::internal::caml_alloc(field_count, 0));
+                let record: $crate::OCamlRef<()> = record.keep_raw($crate::internal::caml_alloc(field_count, 0));
                 $(
                     let $field = &$crate::prepare_field_for_mapping!($self.$field $(=> $conv_expr)?);
                     let $field: $crate::OCaml<$ocaml_typ> = $crate::to_ocaml!($cr, $field);
@@ -737,7 +737,7 @@ macro_rules! impl_from_ocaml_variant {
 /// // NOTE: What is important is the order of the tags, not their names.
 ///
 /// # fn unpack_variant_example(cr: &mut OCamlRuntime) {
-/// let ocaml_variant = make_ocaml_movement(cr, &OCamlRoot::unit());
+/// let ocaml_variant = make_ocaml_movement(cr, &OCamlRef::unit());
 /// let result = ocaml_unpack_variant! {
 ///     ocaml_variant => {
 ///         // Alternative: StepLeft  => Movement::StepLeft
@@ -982,7 +982,7 @@ macro_rules! impl_from_ocaml_polymorphic_variant {
 /// //      ]
 ///
 /// # fn unpack_polymorphic_variant_example(cr: &mut OCamlRuntime) {
-/// let ocaml_polymorphic_variant = make_ocaml_polymorphic_movement(cr, &OCamlRoot::unit());
+/// let ocaml_polymorphic_variant = make_ocaml_polymorphic_movement(cr, &OCamlRef::unit());
 /// let result = ocaml_unpack_polymorphic_variant! {
 ///     ocaml_polymorphic_variant => {
 ///         StepLeft  => Movement::StepLeft,
@@ -1289,7 +1289,7 @@ macro_rules! expand_rooted_args_init {
     (($($roots:ident)*), $arg:ident : f64, $($args:tt)*) =>
         ($crate::expand_rooted_args_init!(($($roots)*), $($args)*));
 
-    // Other values are wrapped in `OCamlRoot<T>` as given the same lifetime as the OCaml runtime handle borrow.
+    // Other values are wrapped in `OCamlRef<T>` as given the same lifetime as the OCaml runtime handle borrow.
     (($root:ident), $arg:ident : $typ:ty) =>
         (let $arg : $typ = unsafe { &$root.keep_raw($arg) };);
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -139,7 +139,7 @@ impl<'a, T> OCamlRooted<'a, T> {
     }
 
     /// Gets the raw value contained by this reference.
-    pub fn get_raw(&self) -> RawOCaml {
+    pub unsafe fn get_raw(&self) -> RawOCaml {
         self.cell.get()
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -146,7 +146,11 @@ impl<'a, T> OCamlRooted<'a, T> {
         self.cell.set(unsafe { x.raw() });
     }
 
-    /// Gets the raw value contained by this reference.
+    /// Borrows the raw value contained in this root.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe, because the RawOCaml value obtained will not be tracked.
     pub unsafe fn get_raw(&self) -> RawOCaml {
         self.cell.get()
     }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -138,7 +138,7 @@ impl<'a, T> OCamlRooted<'a, T> {
     where
         RustT: FromOCaml<T>,
     {
-        RustT::from_ocaml(cr.get(self))
+        RustT::from_ocaml(&cr.get(self))
     }
 
     /// Updates the value of this GC tracked reference.

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -148,7 +148,7 @@ impl<'a, T> OCamlRef<'a, T> {
     where
         RustT: FromOCaml<T>,
     {
-        RustT::from_ocaml(&cr.get(self))
+        RustT::from_ocaml(cr.get(self))
     }
 
     /// Borrows the raw value contained in this root.

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -93,7 +93,8 @@ impl<'a> OCamlRawRoot<'a> {
     pub unsafe fn reserve<'gc>(_gc: &GCFrame<'gc>) -> OCamlRawRoot<'gc> {
         assert_eq!(&_gc.block as *const _, local_roots());
         let block = &mut *local_roots();
-        let locals: *const UnsafeCell<RawOCaml> = &*(block.local_roots as *const UnsafeCell<RawOCaml>);
+        let locals: *const UnsafeCell<RawOCaml> =
+            &*(block.local_roots as *const UnsafeCell<RawOCaml>);
         let cell = &*locals.offset(block.nitems);
         block.nitems += 1;
         OCamlRawRoot { cell }
@@ -127,7 +128,6 @@ impl<'a> OCamlRawRoot<'a> {
 ///
 /// Roots can be used to recover a fresh reference to an [`OCaml`]`<T>` value what would
 /// otherwise become stale after a call to the OCaml runtime.
-#[derive(Copy)]
 pub struct OCamlRef<'a, T> {
     cell: &'a UnsafeCell<RawOCaml>,
     _marker: PhantomData<T>,
@@ -141,6 +141,8 @@ impl<'a, T> Clone for OCamlRef<'a, T> {
         }
     }
 }
+
+impl<'a, T> Copy for OCamlRef<'a, T> {}
 
 impl<'a, T> OCamlRef<'a, T> {
     /// Converts this value into a Rust value.

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -164,7 +164,7 @@ impl OCamlRooted<'static, ()> {
     pub fn unit() -> OCamlRooted<'static, ()> {
         OCamlRooted {
             cell: &ROOTED_UNIT.0,
-            _marker: PhantomData
+            _marker: PhantomData,
         }
     }
 }
@@ -174,7 +174,7 @@ impl<T> OCamlRooted<'static, Option<T>> {
     pub fn none() -> OCamlRooted<'static, Option<T>> {
         OCamlRooted {
             cell: &ROOTED_NONE.0,
-            _marker: PhantomData
+            _marker: PhantomData,
         }
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -203,15 +203,15 @@ pub fn alloc_string<'a>(cr: &'a mut OCamlRuntime, s: &str) -> OCaml<'a, String> 
     }
 }
 
-pub fn alloc_int32<'a>(cr: &'a mut OCamlRuntime, i: i32) -> OCaml<'a, OCamlInt32> {
+pub fn alloc_int32(cr: &mut OCamlRuntime, i: i32) -> OCaml<OCamlInt32> {
     unsafe { OCaml::new(cr, caml_copy_int32(i)) }
 }
 
-pub fn alloc_int64<'a>(cr: &'a mut OCamlRuntime, i: i64) -> OCaml<'a, OCamlInt64> {
+pub fn alloc_int64(cr: &mut OCamlRuntime, i: i64) -> OCaml<OCamlInt64> {
     unsafe { OCaml::new(cr, caml_copy_int64(i)) }
 }
 
-pub fn alloc_double<'a>(cr: &'a mut OCamlRuntime, d: f64) -> OCaml<'a, OCamlFloat> {
+pub fn alloc_double(cr: &mut OCamlRuntime, d: f64) -> OCaml<OCamlFloat> {
     unsafe { OCaml::new(cr, caml_copy_double(d)) }
 }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -152,6 +152,33 @@ impl<'a, T> OCamlRooted<'a, T> {
     }
 }
 
+struct ConstantRoot(Cell<RawOCaml>);
+
+unsafe impl Sync for ConstantRoot {}
+
+static ROOTED_UNIT: ConstantRoot = ConstantRoot(Cell::new(ocaml_sys::UNIT));
+static ROOTED_NONE: ConstantRoot = ConstantRoot(Cell::new(ocaml_sys::NONE));
+
+impl OCamlRooted<'static, ()> {
+    /// Convenience constructor for rooted unit values.
+    pub fn unit() -> OCamlRooted<'static, ()> {
+        OCamlRooted {
+            cell: &ROOTED_UNIT.0,
+            _marker: PhantomData
+        }
+    }
+}
+
+impl<T> OCamlRooted<'static, Option<T>> {
+    /// Convenience constructor for rooted None values.
+    pub fn none() -> OCamlRooted<'static, Option<T>> {
+        OCamlRooted {
+            cell: &ROOTED_NONE.0,
+            _marker: PhantomData
+        }
+    }
+}
+
 pub fn alloc_bytes<'a>(cr: &'a mut OCamlRuntime, s: &[u8]) -> OCaml<'a, OCamlBytes> {
     unsafe {
         let len = s.len();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,7 +4,7 @@
 use ocaml_sys::{caml_shutdown, caml_startup};
 use std::marker::PhantomData;
 
-use crate::{memory::GCFrame, memory::OCamlRoot, value::OCaml};
+use crate::{memory::GCFrame, memory::OCamlRef, value::OCaml};
 
 /// OCaml runtime handle.
 pub struct OCamlRuntime {
@@ -57,7 +57,7 @@ impl OCamlRuntime {
     }
 
     /// Returns the OCaml valued to which this GC tracked reference points to.
-    pub fn get<'tmp, T>(&'tmp self, reference: &OCamlRoot<T>) -> OCaml<'tmp, T> {
+    pub fn get<'tmp, T>(&'tmp self, reference: &OCamlRef<T>) -> OCaml<'tmp, T> {
         OCaml {
             _marker: PhantomData,
             raw: reference.cell.get(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,7 +4,7 @@
 use ocaml_sys::{caml_shutdown, caml_startup};
 use std::marker::PhantomData;
 
-use crate::{memory::GCFrame, memory::OCamlRooted, value::OCaml};
+use crate::{memory::GCFrame, memory::OCamlRoot, value::OCaml};
 
 /// OCaml runtime handle.
 pub struct OCamlRuntime {
@@ -57,7 +57,7 @@ impl OCamlRuntime {
     }
 
     /// Returns the OCaml valued to which this GC tracked reference points to.
-    pub fn get<'tmp, T>(&'tmp self, reference: &OCamlRooted<T>) -> OCaml<'tmp, T> {
+    pub fn get<'tmp, T>(&'tmp self, reference: &OCamlRoot<T>) -> OCaml<'tmp, T> {
         OCaml {
             _marker: PhantomData,
             raw: reference.cell.get(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -57,7 +57,7 @@ impl OCamlRuntime {
     }
 
     /// Returns the OCaml valued to which this GC tracked reference points to.
-    pub fn get<'tmp, T>(&'tmp self, reference: &OCamlRef<T>) -> OCaml<'tmp, T> {
+    pub fn get<'tmp, T>(&'tmp self, reference: OCamlRef<T>) -> OCaml<'tmp, T> {
         OCaml {
             _marker: PhantomData,
             raw: reference.cell.get(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,7 +4,7 @@
 use ocaml_sys::{caml_shutdown, caml_startup};
 use std::marker::PhantomData;
 
-use crate::{memory::GCFrame, value::OCaml, memory::OCamlRooted};
+use crate::{memory::GCFrame, memory::OCamlRooted, value::OCaml};
 
 /// OCaml runtime handle.
 pub struct OCamlRuntime {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -60,7 +60,7 @@ impl OCamlRuntime {
     pub fn get<'tmp, T>(&'tmp self, reference: OCamlRef<T>) -> OCaml<'tmp, T> {
         OCaml {
             _marker: PhantomData,
-            raw: reference.cell.get(),
+            raw: unsafe { reference.get_raw() },
         }
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -51,18 +51,6 @@ impl OCamlRuntime {
         unsafe { caml_shutdown() }
     }
 
-    /// Produces a token that can be used to recover the OCaml runtime handle.
-    ///
-    /// # Safety
-    ///
-    /// Meant to be used internally when calling allocation functions, do not use
-    /// directly.
-    pub unsafe fn token(&self) -> OCamlAllocToken {
-        OCamlAllocToken {
-            _marker: PhantomData,
-        }
-    }
-
     #[doc(hidden)]
     pub fn open_frame<'a, 'gc>(&'a self) -> GCFrame<'gc> {
         Default::default()
@@ -96,24 +84,5 @@ impl OCamlBlockingSection {
 impl Drop for OCamlBlockingSection {
     fn drop(&mut self) {
         unsafe { ocaml_sys::caml_leave_blocking_section() };
-    }
-}
-
-/// Token used by allocation functions. Used internally.
-pub struct OCamlAllocToken<'a> {
-    _marker: PhantomData<&'a i32>,
-}
-
-impl<'a> OCamlAllocToken<'a> {
-    /// Recover the runtime handle from this token.
-    ///
-    /// # Safety
-    ///
-    /// It is important that functions that make use of this method of
-    /// recovering the function handle are only called with the [`ocaml_alloc!`]
-    /// and [`ocaml_call!`] macros to perform the necessary bookkeeping operations
-    /// to enforce the correctness of OCaml value lifetimes.
-    pub unsafe fn recover_runtime_handle(self) -> OCamlRuntime {
-        OCamlRuntime::recover_handle()
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,7 +1,7 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use crate::{FromOCaml, OCamlRuntime, error::OCamlFixnumConversionError, mlvalues::*};
+use crate::{error::OCamlFixnumConversionError, mlvalues::*, FromOCaml, OCamlRuntime};
 use core::{marker::PhantomData, slice, str};
 use ocaml_sys::{caml_string_length, int_val, val_int};
 
@@ -86,7 +86,10 @@ impl<'a, T> OCaml<'a, T> {
     /// # Example
     ///
     /// TODO
-    pub fn to_rust<RustT>(&self) -> RustT where RustT: FromOCaml<T> {
+    pub fn to_rust<RustT>(&self) -> RustT
+    where
+        RustT: FromOCaml<T>,
+    {
         RustT::from_ocaml(self.clone())
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -82,10 +82,6 @@ impl<'a, T> OCaml<'a, T> {
     }
 
     /// Converts this OCaml value into a Rust value.
-    ///
-    /// # Example
-    ///
-    /// TODO
     pub fn to_rust<RustT>(&self) -> RustT
     where
         RustT: FromOCaml<T>,

--- a/src/value.rs
+++ b/src/value.rs
@@ -291,6 +291,10 @@ impl<'a, A, Err> OCaml<'a, Result<A, Err>> {
 }
 
 impl<'a, A, B> OCaml<'a, (A, B)> {
+    pub fn to_tuple(&self) -> (OCaml<'a, A>, OCaml<'a, B>) {
+        (self.fst(), self.snd())
+    }
+
     pub fn fst(&self) -> OCaml<'a, A> {
         unsafe { self.field(0) }
     }
@@ -301,6 +305,10 @@ impl<'a, A, B> OCaml<'a, (A, B)> {
 }
 
 impl<'a, A, B, C> OCaml<'a, (A, B, C)> {
+    pub fn to_tuple(&self) -> (OCaml<'a, A>, OCaml<'a, B>, OCaml<'a, C>) {
+        (self.fst(), self.snd(), self.tuple_3())
+    }
+
     pub fn fst(&self) -> OCaml<'a, A> {
         unsafe { self.field(0) }
     }
@@ -315,6 +323,10 @@ impl<'a, A, B, C> OCaml<'a, (A, B, C)> {
 }
 
 impl<'a, A, B, C, D> OCaml<'a, (A, B, C, D)> {
+    pub fn to_tuple(&self) -> (OCaml<'a, A>, OCaml<'a, B>, OCaml<'a, C>, OCaml<'a, D>) {
+        (self.fst(), self.snd(), self.tuple_3(), self.tuple_4())
+    }
+
     pub fn fst(&self) -> OCaml<'a, A> {
         unsafe { self.field(0) }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,7 +6,6 @@ use core::{marker::PhantomData, slice, str};
 use ocaml_sys::{caml_string_length, int_val, val_int};
 
 /// Representation of OCaml values.
-#[derive(Copy)]
 pub struct OCaml<'a, T: 'a> {
     pub(crate) _marker: PhantomData<&'a T>,
     pub(crate) raw: RawOCaml,
@@ -20,6 +19,8 @@ impl<'a, T> Clone for OCaml<'a, T> {
         }
     }
 }
+
+impl<'a, T> Copy for OCaml<'a, T> {}
 
 impl<'a, T> OCaml<'a, T> {
     #[doc(hidden)]

--- a/src/value.rs
+++ b/src/value.rs
@@ -86,7 +86,7 @@ impl<'a, T> OCaml<'a, T> {
     where
         RustT: FromOCaml<T>,
     {
-        RustT::from_ocaml(self)
+        RustT::from_ocaml(self.clone())
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,7 +1,7 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use crate::{error::OCamlFixnumConversionError, mlvalues::*, FromOCaml, OCamlRoot, OCamlRuntime};
+use crate::{error::OCamlFixnumConversionError, mlvalues::*, FromOCaml, OCamlRef, OCamlRuntime};
 use core::{marker::PhantomData, slice, str};
 use ocaml_sys::{caml_string_length, int_val, val_int};
 
@@ -92,7 +92,7 @@ impl<'a, T> OCaml<'a, T> {
 
 impl<T> OCaml<'static, T> {
     /// Gets an immediate OCaml value as a root containing that value.
-    pub fn as_root(&self) -> OCamlRoot<T> {
+    pub fn as_value_ref(&self) -> OCamlRef<T> {
         unsafe { std::mem::transmute(self) }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,10 +6,6 @@ use core::{marker::PhantomData, slice, str};
 use ocaml_sys::{caml_string_length, int_val, val_int};
 
 /// Representation of OCaml values.
-///
-/// Should not be instantiated directly, and will usually be the result
-/// of [`ocaml_alloc!`] and [`ocaml_call!`] expressions, or the input arguments
-/// of functions defined inside [`ocaml_export!`] blocks.
 #[derive(Copy)]
 pub struct OCaml<'a, T: 'a> {
     pub(crate) _marker: PhantomData<&'a T>,

--- a/src/value.rs
+++ b/src/value.rs
@@ -86,7 +86,7 @@ impl<'a, T> OCaml<'a, T> {
     where
         RustT: FromOCaml<T>,
     {
-        RustT::from_ocaml(self.clone())
+        RustT::from_ocaml(self)
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,7 +1,7 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use crate::{error::OCamlFixnumConversionError, mlvalues::*, FromOCaml, OCamlRuntime};
+use crate::{error::OCamlFixnumConversionError, mlvalues::*, FromOCaml, OCamlRoot, OCamlRuntime};
 use core::{marker::PhantomData, slice, str};
 use ocaml_sys::{caml_string_length, int_val, val_int};
 
@@ -87,6 +87,13 @@ impl<'a, T> OCaml<'a, T> {
         RustT: FromOCaml<T>,
     {
         RustT::from_ocaml(self)
+    }
+}
+
+impl<T> OCaml<'static, T> {
+    /// Gets an immediate OCaml value as a root containing that value.
+    pub fn as_root(&self) -> OCamlRoot<T> {
+        unsafe { std::mem::transmute(self) }
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -87,7 +87,7 @@ impl<'a, T> OCaml<'a, T> {
     where
         RustT: FromOCaml<T>,
     {
-        RustT::from_ocaml(self.clone())
+        RustT::from_ocaml(*self)
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -216,7 +216,7 @@ impl<'a> OCaml<'a, bool> {
     }
 
     /// Creates an OCaml boolean from a Rust boolean.
-    pub fn of_bool(b: bool) -> Self {
+    pub fn of_bool(b: bool) -> OCaml<'static, bool> {
         OCaml {
             _marker: PhantomData,
             raw: if b { TRUE } else { FALSE },

--- a/src/value.rs
+++ b/src/value.rs
@@ -211,7 +211,7 @@ impl<'a> OCaml<'a, OCamlInt> {
 
 impl<'a> OCaml<'a, bool> {
     /// Converts an OCaml boolean into a Rust boolean.
-    pub fn to_bool(self) -> bool {
+    pub fn to_bool(&self) -> bool {
         int_val(self.raw) != 0
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -167,7 +167,7 @@ impl<'a> OCaml<'a, OCamlBytes> {
 
 impl<'a> OCaml<'a, OCamlInt> {
     /// Converts an OCaml int to an `i64`.
-    pub fn as_i64(&self) -> i64 {
+    pub fn to_i64(&self) -> i64 {
         int_val(self.raw) as i64
     }
 
@@ -212,7 +212,7 @@ impl<'a> OCaml<'a, OCamlInt> {
 
 impl<'a> OCaml<'a, bool> {
     /// Converts an OCaml boolean into a Rust boolean.
-    pub fn as_bool(self) -> bool {
+    pub fn to_bool(self) -> bool {
         int_val(self.raw) != 0
     }
 

--- a/testing/ocaml-caller/rust/src/lib.rs
+++ b/testing/ocaml-caller/rust/src/lib.rs
@@ -3,7 +3,7 @@
 
 use ocaml_interop::{
     ocaml_export, ocaml_unpack_polymorphic_variant, ocaml_unpack_variant, to_ocaml,
-    OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, OCamlRoot,
+    OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, OCamlRef,
     ToOCaml,
 };
 use std::{thread, time};
@@ -21,18 +21,18 @@ enum PolymorphicMovement {
 }
 
 ocaml_export! {
-    fn rust_twice(cr, num: &OCamlRoot<OCamlInt>) -> OCaml<OCamlInt> {
+    fn rust_twice(cr, num: &OCamlRef<OCamlInt>) -> OCaml<OCamlInt> {
         let num: i64 = num.to_rust(cr);
         unsafe { OCaml::of_i64_unchecked(num * 2) }
     }
 
-    fn rust_twice_boxed_i64(cr, num: &OCamlRoot<OCamlInt64>) -> OCaml<OCamlInt64> {
+    fn rust_twice_boxed_i64(cr, num: &OCamlRef<OCamlInt64>) -> OCaml<OCamlInt64> {
         let num: i64 = num.to_rust(cr);
         let result = num * 2;
         result.to_ocaml(cr)
     }
 
-    fn rust_twice_boxed_i32(cr, num: &OCamlRoot<OCamlInt32>) -> OCaml<OCamlInt32> {
+    fn rust_twice_boxed_i32(cr, num: &OCamlRef<OCamlInt32>) -> OCaml<OCamlInt32> {
         let num: i32 = num.to_rust(cr);
         let result = num * 2;
         result.to_ocaml(cr)
@@ -42,7 +42,7 @@ ocaml_export! {
         num * num2
     }
 
-    fn rust_twice_boxed_float(cr, num: &OCamlRoot<OCamlFloat>) -> OCaml<OCamlFloat> {
+    fn rust_twice_boxed_float(cr, num: &OCamlRef<OCamlFloat>) -> OCaml<OCamlFloat> {
         let num: f64 = num.to_rust(cr);
         let result = num * 2.0;
         result.to_ocaml(cr)
@@ -52,7 +52,7 @@ ocaml_export! {
         num * 2.0
     }
 
-    fn rust_increment_bytes(cr, bytes: &OCamlRoot<OCamlBytes>, first_n: &OCamlRoot<OCamlInt>) -> OCaml<OCamlBytes> {
+    fn rust_increment_bytes(cr, bytes: &OCamlRef<OCamlBytes>, first_n: &OCamlRef<OCamlInt>) -> OCaml<OCamlBytes> {
         let first_n: i64 = first_n.to_rust(cr);
         let first_n = first_n as usize;
         let mut vec: Vec<u8> = bytes.to_rust(cr);
@@ -64,7 +64,7 @@ ocaml_export! {
         vec.to_ocaml(cr)
     }
 
-    fn rust_increment_ints_list(cr, ints: &OCamlRoot<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
+    fn rust_increment_ints_list(cr, ints: &OCamlRef<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
         let mut vec: Vec<i64> = ints.to_rust(cr);
 
         for i in 0..vec.len() {
@@ -74,44 +74,44 @@ ocaml_export! {
         vec.to_ocaml(cr)
     }
 
-    fn rust_make_tuple(cr, fst: &OCamlRoot<String>, snd: &OCamlRoot<OCamlInt>) -> OCaml<(String, OCamlInt)> {
+    fn rust_make_tuple(cr, fst: &OCamlRef<String>, snd: &OCamlRef<OCamlInt>) -> OCaml<(String, OCamlInt)> {
         let fst: String = fst.to_rust(cr);
         let snd: i64 = snd.to_rust(cr);
         let tuple = (fst, snd);
         tuple.to_ocaml(cr)
     }
 
-    fn rust_make_some(cr, value: &OCamlRoot<String>) -> OCaml<Option<String>> {
+    fn rust_make_some(cr, value: &OCamlRef<String>) -> OCaml<Option<String>> {
         let value: String = value.to_rust(cr);
         let some_value = Some(value);
         some_value.to_ocaml(cr)
     }
 
-    fn rust_make_ok(cr, value: &OCamlRoot<OCamlInt>) -> OCaml<Result<OCamlInt, String>> {
+    fn rust_make_ok(cr, value: &OCamlRef<OCamlInt>) -> OCaml<Result<OCamlInt, String>> {
         let value: i64 = value.to_rust(cr);
         let ok_value: Result<i64, String> = Ok(value);
         to_ocaml!(cr, ok_value)
     }
 
-    fn rust_make_error(cr, value: &OCamlRoot<String>) -> OCaml<Result<OCamlInt, String>> {
+    fn rust_make_error(cr, value: &OCamlRef<String>) -> OCaml<Result<OCamlInt, String>> {
         let value: String = value.to_rust(cr);
         let error_value: Result<i64, String> = Err(value);
         to_ocaml!(cr, error_value)
     }
 
-    fn rust_sleep_releasing(cr, millis: &OCamlRoot<OCamlInt>) {
+    fn rust_sleep_releasing(cr, millis: &OCamlRef<OCamlInt>) {
         let millis: i64 = millis.to_rust(cr);
         cr.releasing_runtime(|| thread::sleep(time::Duration::from_millis(millis as u64)));
         OCaml::unit()
     }
 
-    fn rust_sleep(cr, millis: &OCamlRoot<OCamlInt>) {
+    fn rust_sleep(cr, millis: &OCamlRef<OCamlInt>) {
         let millis: i64 = millis.to_rust(cr);
         thread::sleep(time::Duration::from_millis(millis as u64));
         OCaml::unit()
     }
 
-    fn rust_string_of_movement(cr, movement: &OCamlRoot<PolymorphicMovement>) -> OCaml<String> {
+    fn rust_string_of_movement(cr, movement: &OCamlRef<PolymorphicMovement>) -> OCaml<String> {
         let movement = cr.get(movement);
         let pm = ocaml_unpack_variant! {
             movement => {
@@ -129,7 +129,7 @@ ocaml_export! {
         to_ocaml!(cr, s)
     }
 
-    fn rust_string_of_polymorphic_movement(cr, polymorphic_movement: &OCamlRoot<PolymorphicMovement>) -> OCaml<String> {
+    fn rust_string_of_polymorphic_movement(cr, polymorphic_movement: &OCamlRef<PolymorphicMovement>) -> OCaml<String> {
         let polymorphic_movement = cr.get(polymorphic_movement);
         let pm = ocaml_unpack_polymorphic_variant! {
             polymorphic_movement => {

--- a/testing/ocaml-caller/rust/src/lib.rs
+++ b/testing/ocaml-caller/rust/src/lib.rs
@@ -21,18 +21,18 @@ enum PolymorphicMovement {
 }
 
 ocaml_export! {
-    fn rust_twice(cr, num: &OCamlRef<OCamlInt>) -> OCaml<OCamlInt> {
+    fn rust_twice(cr, num: OCamlRef<OCamlInt>) -> OCaml<OCamlInt> {
         let num: i64 = num.to_rust(cr);
         unsafe { OCaml::of_i64_unchecked(num * 2) }
     }
 
-    fn rust_twice_boxed_i64(cr, num: &OCamlRef<OCamlInt64>) -> OCaml<OCamlInt64> {
+    fn rust_twice_boxed_i64(cr, num: OCamlRef<OCamlInt64>) -> OCaml<OCamlInt64> {
         let num: i64 = num.to_rust(cr);
         let result = num * 2;
         result.to_ocaml(cr)
     }
 
-    fn rust_twice_boxed_i32(cr, num: &OCamlRef<OCamlInt32>) -> OCaml<OCamlInt32> {
+    fn rust_twice_boxed_i32(cr, num: OCamlRef<OCamlInt32>) -> OCaml<OCamlInt32> {
         let num: i32 = num.to_rust(cr);
         let result = num * 2;
         result.to_ocaml(cr)
@@ -42,7 +42,7 @@ ocaml_export! {
         num * num2
     }
 
-    fn rust_twice_boxed_float(cr, num: &OCamlRef<OCamlFloat>) -> OCaml<OCamlFloat> {
+    fn rust_twice_boxed_float(cr, num: OCamlRef<OCamlFloat>) -> OCaml<OCamlFloat> {
         let num: f64 = num.to_rust(cr);
         let result = num * 2.0;
         result.to_ocaml(cr)
@@ -52,7 +52,7 @@ ocaml_export! {
         num * 2.0
     }
 
-    fn rust_increment_bytes(cr, bytes: &OCamlRef<OCamlBytes>, first_n: &OCamlRef<OCamlInt>) -> OCaml<OCamlBytes> {
+    fn rust_increment_bytes(cr, bytes: OCamlRef<OCamlBytes>, first_n: OCamlRef<OCamlInt>) -> OCaml<OCamlBytes> {
         let first_n: i64 = first_n.to_rust(cr);
         let first_n = first_n as usize;
         let mut vec: Vec<u8> = bytes.to_rust(cr);
@@ -64,7 +64,7 @@ ocaml_export! {
         vec.to_ocaml(cr)
     }
 
-    fn rust_increment_ints_list(cr, ints: &OCamlRef<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
+    fn rust_increment_ints_list(cr, ints: OCamlRef<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
         let mut vec: Vec<i64> = ints.to_rust(cr);
 
         for i in 0..vec.len() {
@@ -74,44 +74,44 @@ ocaml_export! {
         vec.to_ocaml(cr)
     }
 
-    fn rust_make_tuple(cr, fst: &OCamlRef<String>, snd: &OCamlRef<OCamlInt>) -> OCaml<(String, OCamlInt)> {
+    fn rust_make_tuple(cr, fst: OCamlRef<String>, snd: OCamlRef<OCamlInt>) -> OCaml<(String, OCamlInt)> {
         let fst: String = fst.to_rust(cr);
         let snd: i64 = snd.to_rust(cr);
         let tuple = (fst, snd);
         tuple.to_ocaml(cr)
     }
 
-    fn rust_make_some(cr, value: &OCamlRef<String>) -> OCaml<Option<String>> {
+    fn rust_make_some(cr, value: OCamlRef<String>) -> OCaml<Option<String>> {
         let value: String = value.to_rust(cr);
         let some_value = Some(value);
         some_value.to_ocaml(cr)
     }
 
-    fn rust_make_ok(cr, value: &OCamlRef<OCamlInt>) -> OCaml<Result<OCamlInt, String>> {
+    fn rust_make_ok(cr, value: OCamlRef<OCamlInt>) -> OCaml<Result<OCamlInt, String>> {
         let value: i64 = value.to_rust(cr);
         let ok_value: Result<i64, String> = Ok(value);
         to_ocaml!(cr, ok_value)
     }
 
-    fn rust_make_error(cr, value: &OCamlRef<String>) -> OCaml<Result<OCamlInt, String>> {
+    fn rust_make_error(cr, value: OCamlRef<String>) -> OCaml<Result<OCamlInt, String>> {
         let value: String = value.to_rust(cr);
         let error_value: Result<i64, String> = Err(value);
         to_ocaml!(cr, error_value)
     }
 
-    fn rust_sleep_releasing(cr, millis: &OCamlRef<OCamlInt>) {
+    fn rust_sleep_releasing(cr, millis: OCamlRef<OCamlInt>) {
         let millis: i64 = millis.to_rust(cr);
         cr.releasing_runtime(|| thread::sleep(time::Duration::from_millis(millis as u64)));
         OCaml::unit()
     }
 
-    fn rust_sleep(cr, millis: &OCamlRef<OCamlInt>) {
+    fn rust_sleep(cr, millis: OCamlRef<OCamlInt>) {
         let millis: i64 = millis.to_rust(cr);
         thread::sleep(time::Duration::from_millis(millis as u64));
         OCaml::unit()
     }
 
-    fn rust_string_of_movement(cr, movement: &OCamlRef<PolymorphicMovement>) -> OCaml<String> {
+    fn rust_string_of_movement(cr, movement: OCamlRef<PolymorphicMovement>) -> OCaml<String> {
         let movement = cr.get(movement);
         let pm = ocaml_unpack_variant! {
             movement => {
@@ -129,7 +129,7 @@ ocaml_export! {
         to_ocaml!(cr, s)
     }
 
-    fn rust_string_of_polymorphic_movement(cr, polymorphic_movement: &OCamlRef<PolymorphicMovement>) -> OCaml<String> {
+    fn rust_string_of_polymorphic_movement(cr, polymorphic_movement: OCamlRef<PolymorphicMovement>) -> OCaml<String> {
         let polymorphic_movement = cr.get(polymorphic_movement);
         let pm = ocaml_unpack_polymorphic_variant! {
             polymorphic_movement => {

--- a/testing/ocaml-caller/rust/src/lib.rs
+++ b/testing/ocaml-caller/rust/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use ocaml_interop::{
-    ocaml_alloc, ocaml_export, ocaml_unpack_polymorphic_variant, ocaml_unpack_variant, to_ocaml,
+    ocaml_export, ocaml_unpack_polymorphic_variant, ocaml_unpack_variant, to_ocaml,
     OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, OCamlRooted,
     ToOCaml,
 };
@@ -29,13 +29,13 @@ ocaml_export! {
     fn rust_twice_boxed_i64(cr, num: &OCamlRooted<OCamlInt64>) -> OCaml<OCamlInt64> {
         let num: i64 = num.to_rust(cr);
         let result = num * 2;
-        ocaml_alloc!(result.to_ocaml(cr))
+        result.to_ocaml(cr)
     }
 
     fn rust_twice_boxed_i32(cr, num: &OCamlRooted<OCamlInt32>) -> OCaml<OCamlInt32> {
         let num: i32 = num.to_rust(cr);
         let result = num * 2;
-        ocaml_alloc!(result.to_ocaml(cr))
+        result.to_ocaml(cr)
     }
 
     fn rust_add_unboxed_floats_noalloc(_cr, num: f64, num2: f64) -> f64 {
@@ -45,7 +45,7 @@ ocaml_export! {
     fn rust_twice_boxed_float(cr, num: &OCamlRooted<OCamlFloat>) -> OCaml<OCamlFloat> {
         let num: f64 = num.to_rust(cr);
         let result = num * 2.0;
-        ocaml_alloc!(result.to_ocaml(cr))
+        result.to_ocaml(cr)
     }
 
     fn rust_twice_unboxed_float(_cr, num: f64) -> f64 {
@@ -61,7 +61,7 @@ ocaml_export! {
             vec[i] += 1;
         }
 
-        ocaml_alloc!(vec.to_ocaml(cr))
+        vec.to_ocaml(cr)
     }
 
     fn rust_increment_ints_list(cr, ints: &OCamlRooted<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
@@ -71,20 +71,20 @@ ocaml_export! {
             vec[i] += 1;
         }
 
-        ocaml_alloc!(vec.to_ocaml(cr))
+        vec.to_ocaml(cr)
     }
 
     fn rust_make_tuple(cr, fst: &OCamlRooted<String>, snd: &OCamlRooted<OCamlInt>) -> OCaml<(String, OCamlInt)> {
         let fst: String = fst.to_rust(cr);
         let snd: i64 = snd.to_rust(cr);
         let tuple = (fst, snd);
-        ocaml_alloc!(tuple.to_ocaml(cr))
+        tuple.to_ocaml(cr)
     }
 
     fn rust_make_some(cr, value: &OCamlRooted<String>) -> OCaml<Option<String>> {
         let value: String = value.to_rust(cr);
         let some_value = Some(value);
-        ocaml_alloc!(some_value.to_ocaml(cr))
+        some_value.to_ocaml(cr)
     }
 
     fn rust_make_ok(cr, value: &OCamlRooted<OCamlInt>) -> OCaml<Result<OCamlInt, String>> {

--- a/testing/ocaml-caller/rust/src/lib.rs
+++ b/testing/ocaml-caller/rust/src/lib.rs
@@ -3,7 +3,7 @@
 
 use ocaml_interop::{
     ocaml_export, ocaml_unpack_polymorphic_variant, ocaml_unpack_variant, to_ocaml,
-    OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, OCamlRooted,
+    OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, OCamlRoot,
     ToOCaml,
 };
 use std::{thread, time};
@@ -21,18 +21,18 @@ enum PolymorphicMovement {
 }
 
 ocaml_export! {
-    fn rust_twice(cr, num: &OCamlRooted<OCamlInt>) -> OCaml<OCamlInt> {
+    fn rust_twice(cr, num: &OCamlRoot<OCamlInt>) -> OCaml<OCamlInt> {
         let num: i64 = num.to_rust(cr);
         unsafe { OCaml::of_i64_unchecked(num * 2) }
     }
 
-    fn rust_twice_boxed_i64(cr, num: &OCamlRooted<OCamlInt64>) -> OCaml<OCamlInt64> {
+    fn rust_twice_boxed_i64(cr, num: &OCamlRoot<OCamlInt64>) -> OCaml<OCamlInt64> {
         let num: i64 = num.to_rust(cr);
         let result = num * 2;
         result.to_ocaml(cr)
     }
 
-    fn rust_twice_boxed_i32(cr, num: &OCamlRooted<OCamlInt32>) -> OCaml<OCamlInt32> {
+    fn rust_twice_boxed_i32(cr, num: &OCamlRoot<OCamlInt32>) -> OCaml<OCamlInt32> {
         let num: i32 = num.to_rust(cr);
         let result = num * 2;
         result.to_ocaml(cr)
@@ -42,7 +42,7 @@ ocaml_export! {
         num * num2
     }
 
-    fn rust_twice_boxed_float(cr, num: &OCamlRooted<OCamlFloat>) -> OCaml<OCamlFloat> {
+    fn rust_twice_boxed_float(cr, num: &OCamlRoot<OCamlFloat>) -> OCaml<OCamlFloat> {
         let num: f64 = num.to_rust(cr);
         let result = num * 2.0;
         result.to_ocaml(cr)
@@ -52,7 +52,7 @@ ocaml_export! {
         num * 2.0
     }
 
-    fn rust_increment_bytes(cr, bytes: &OCamlRooted<OCamlBytes>, first_n: &OCamlRooted<OCamlInt>) -> OCaml<OCamlBytes> {
+    fn rust_increment_bytes(cr, bytes: &OCamlRoot<OCamlBytes>, first_n: &OCamlRoot<OCamlInt>) -> OCaml<OCamlBytes> {
         let first_n: i64 = first_n.to_rust(cr);
         let first_n = first_n as usize;
         let mut vec: Vec<u8> = bytes.to_rust(cr);
@@ -64,7 +64,7 @@ ocaml_export! {
         vec.to_ocaml(cr)
     }
 
-    fn rust_increment_ints_list(cr, ints: &OCamlRooted<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
+    fn rust_increment_ints_list(cr, ints: &OCamlRoot<OCamlList<OCamlInt>>) -> OCaml<OCamlList<OCamlInt>> {
         let mut vec: Vec<i64> = ints.to_rust(cr);
 
         for i in 0..vec.len() {
@@ -74,44 +74,44 @@ ocaml_export! {
         vec.to_ocaml(cr)
     }
 
-    fn rust_make_tuple(cr, fst: &OCamlRooted<String>, snd: &OCamlRooted<OCamlInt>) -> OCaml<(String, OCamlInt)> {
+    fn rust_make_tuple(cr, fst: &OCamlRoot<String>, snd: &OCamlRoot<OCamlInt>) -> OCaml<(String, OCamlInt)> {
         let fst: String = fst.to_rust(cr);
         let snd: i64 = snd.to_rust(cr);
         let tuple = (fst, snd);
         tuple.to_ocaml(cr)
     }
 
-    fn rust_make_some(cr, value: &OCamlRooted<String>) -> OCaml<Option<String>> {
+    fn rust_make_some(cr, value: &OCamlRoot<String>) -> OCaml<Option<String>> {
         let value: String = value.to_rust(cr);
         let some_value = Some(value);
         some_value.to_ocaml(cr)
     }
 
-    fn rust_make_ok(cr, value: &OCamlRooted<OCamlInt>) -> OCaml<Result<OCamlInt, String>> {
+    fn rust_make_ok(cr, value: &OCamlRoot<OCamlInt>) -> OCaml<Result<OCamlInt, String>> {
         let value: i64 = value.to_rust(cr);
         let ok_value: Result<i64, String> = Ok(value);
         to_ocaml!(cr, ok_value)
     }
 
-    fn rust_make_error(cr, value: &OCamlRooted<String>) -> OCaml<Result<OCamlInt, String>> {
+    fn rust_make_error(cr, value: &OCamlRoot<String>) -> OCaml<Result<OCamlInt, String>> {
         let value: String = value.to_rust(cr);
         let error_value: Result<i64, String> = Err(value);
         to_ocaml!(cr, error_value)
     }
 
-    fn rust_sleep_releasing(cr, millis: &OCamlRooted<OCamlInt>) {
+    fn rust_sleep_releasing(cr, millis: &OCamlRoot<OCamlInt>) {
         let millis: i64 = millis.to_rust(cr);
         cr.releasing_runtime(|| thread::sleep(time::Duration::from_millis(millis as u64)));
         OCaml::unit()
     }
 
-    fn rust_sleep(cr, millis: &OCamlRooted<OCamlInt>) {
+    fn rust_sleep(cr, millis: &OCamlRoot<OCamlInt>) {
         let millis: i64 = millis.to_rust(cr);
         thread::sleep(time::Duration::from_millis(millis as u64));
         OCaml::unit()
     }
 
-    fn rust_string_of_movement(cr, movement: &OCamlRooted<PolymorphicMovement>) -> OCaml<String> {
+    fn rust_string_of_movement(cr, movement: &OCamlRoot<PolymorphicMovement>) -> OCaml<String> {
         let movement = cr.get(movement);
         let pm = ocaml_unpack_variant! {
             movement => {
@@ -129,7 +129,7 @@ ocaml_export! {
         to_ocaml!(cr, s)
     }
 
-    fn rust_string_of_polymorphic_movement(cr, polymorphic_movement: &OCamlRooted<PolymorphicMovement>) -> OCaml<String> {
+    fn rust_string_of_polymorphic_movement(cr, polymorphic_movement: &OCamlRoot<PolymorphicMovement>) -> OCaml<String> {
         let polymorphic_movement = cr.get(polymorphic_movement);
         let pm = ocaml_unpack_polymorphic_variant! {
             polymorphic_movement => {

--- a/testing/rust-caller/ocaml/callable.ml
+++ b/testing/rust-caller/ocaml/callable.ml
@@ -64,6 +64,14 @@ let stringify_polymorphic_variant = function
   | `RotateRight -> "`RotateRight"
   | `Step n -> Printf.sprintf "`Step(%d)" n
 
+let raises_message_exception msg = failwith msg
+
+let raises_nonblock_exception () = raise Not_found
+
+exception WithInt of int
+
+let raises_nonmessage_exception () = raise (WithInt 10)
+
 let () =
   Callback.register "increment_bytes" increment_bytes;
   Callback.register "decrement_bytes" decrement_bytes;
@@ -75,4 +83,7 @@ let () =
   Callback.register "make_error" make_error;
   Callback.register "stringify_record" stringify_record;
   Callback.register "stringify_variant" stringify_variant;
-  Callback.register "stringify_polymorphic_variant" stringify_polymorphic_variant
+  Callback.register "stringify_polymorphic_variant" stringify_polymorphic_variant;
+  Callback.register "raises_message_exception" raises_message_exception;
+  Callback.register "raises_nonmessage_exception" raises_nonmessage_exception;
+  Callback.register "raises_nonblock_exception" raises_nonblock_exception;

--- a/testing/rust-caller/src/lib.rs
+++ b/testing/rust-caller/src/lib.rs
@@ -3,15 +3,12 @@
 
 extern crate ocaml_interop;
 
-use ocaml_interop::{
-    ocaml_frame, to_ocaml, OCaml, OCamlBytes, OCamlInt, OCamlList, OCamlRuntime,
-    ToOCaml,
-};
+use ocaml_interop::{ocaml_frame, to_ocaml, OCaml, OCamlBytes, OCamlRuntime, ToOCaml};
 
 mod ocaml {
     use ocaml_interop::{
-        impl_to_ocaml_record, impl_to_ocaml_variant, ocaml, OCamlFloat, OCamlInt,
-        OCamlInt32, OCamlInt64, OCamlList,
+        impl_to_ocaml_record, impl_to_ocaml_variant, ocaml, OCamlFloat, OCamlInt, OCamlInt32,
+        OCamlInt64, OCamlList,
     };
 
     pub struct TestRecord {
@@ -65,7 +62,7 @@ pub fn increment_bytes(cr: &mut OCamlRuntime, bytes: &str, first_n: usize) -> St
     ocaml_frame!(cr, (bytes_root, first_n_root), {
         let bytes = to_ocaml!(cr, bytes, bytes_root);
         let first_n = to_ocaml!(cr, first_n as i64, first_n_root);
-        let result = ocaml::increment_bytes(cr, &bytes, &first_n).unwrap();
+        let result = ocaml::increment_bytes(cr, &bytes, &first_n);
         result.to_rust()
     })
 }
@@ -74,8 +71,6 @@ pub fn increment_ints_list(cr: &mut OCamlRuntime, ints: &Vec<i64>) -> Vec<i64> {
     ocaml_frame!(cr, (root), {
         let ints = to_ocaml!(cr, ints, root);
         let result = ocaml::increment_ints_list(cr, &ints);
-        let result: OCaml<OCamlList<OCamlInt>> =
-            result.expect("Error in 'increment_ints_list' call result");
         result.to_rust()
     })
 }
@@ -85,7 +80,6 @@ pub fn twice(cr: &mut OCamlRuntime, num: i64) -> i64 {
         let num = unsafe { OCaml::of_i64_unchecked(num) };
         let num = root.keep(num);
         let result = ocaml::twice(cr, &num);
-        let result: OCaml<OCamlInt> = result.expect("Error in 'twice' call result");
         result.to_rust()
     })
 }
@@ -96,7 +90,6 @@ pub fn make_tuple(cr: &mut OCamlRuntime, fst: String, snd: i64) -> (String, i64)
         let num = num_root.keep(num);
         let str = to_ocaml!(cr, fst, str_root);
         let result = ocaml::make_tuple(cr, &str, &num);
-        let result: OCaml<(String, OCamlInt)> = result.expect("Error in 'make_tuple' call result");
         result.to_rust()
     })
 }
@@ -105,7 +98,6 @@ pub fn make_some(cr: &mut OCamlRuntime, value: String) -> Option<String> {
     ocaml_frame!(cr, (root), {
         let str = to_ocaml!(cr, value, root);
         let result = ocaml::make_some(cr, &str);
-        let result: OCaml<Option<String>> = result.expect("Error in 'make_some' call result");
         result.to_rust()
     })
 }
@@ -114,8 +106,6 @@ pub fn make_ok(cr: &mut OCamlRuntime, value: i64) -> Result<i64, String> {
     ocaml_frame!(cr, (root), {
         let result = to_ocaml!(cr, value, root);
         let result = ocaml::make_ok(cr, &result);
-        let result: OCaml<Result<OCamlInt, String>> =
-            result.expect("Error in 'make_ok' call result");
         result.to_rust()
     })
 }
@@ -124,8 +114,6 @@ pub fn make_error(cr: &mut OCamlRuntime, value: String) -> Result<i64, String> {
     ocaml_frame!(cr, (root), {
         let result = to_ocaml!(cr, value, root);
         let result = ocaml::make_error(cr, &result);
-        let result: OCaml<Result<OCamlInt, String>> =
-            result.expect("Error in 'make_error' call result");
         result.to_rust()
     })
 }
@@ -134,7 +122,6 @@ pub fn verify_record_test(cr: &mut OCamlRuntime, record: ocaml::TestRecord) -> S
     ocaml_frame!(cr, (root), {
         let ocaml_record = to_ocaml!(cr, record, root);
         let result = ocaml::stringify_record(cr, &ocaml_record);
-        let result: OCaml<String> = result.expect("Error in 'stringify_record' call result");
         result.to_rust()
     })
 }
@@ -143,7 +130,6 @@ pub fn verify_variant_test(cr: &mut OCamlRuntime, variant: ocaml::Movement) -> S
     ocaml_frame!(cr, (root), {
         let ocaml_variant = to_ocaml!(cr, variant, root);
         let result = ocaml::stringify_variant(cr, &ocaml_variant);
-        let result: OCaml<String> = result.expect("Error in 'stringify_variant' call result");
         result.to_rust()
     })
 }

--- a/testing/rust-caller/src/lib.rs
+++ b/testing/rust-caller/src/lib.rs
@@ -62,7 +62,7 @@ pub fn increment_bytes(cr: &mut OCamlRuntime, bytes: &str, first_n: usize) -> St
     ocaml_frame!(cr, (bytes_root), {
         let bytes = to_ocaml!(cr, bytes, bytes_root);
         let first_n = unsafe { OCaml::of_i64_unchecked(first_n as i64) };
-        let result = ocaml::increment_bytes(cr, &bytes, &first_n.as_root());
+        let result = ocaml::increment_bytes(cr, &bytes, &first_n.as_value_ref());
         result.to_rust()
     })
 }
@@ -77,7 +77,7 @@ pub fn increment_ints_list(cr: &mut OCamlRuntime, ints: &Vec<i64>) -> Vec<i64> {
 
 pub fn twice(cr: &mut OCamlRuntime, num: i64) -> i64 {
     let num = unsafe { OCaml::of_i64_unchecked(num) };
-    let result = ocaml::twice(cr, &num.as_root());
+    let result = ocaml::twice(cr, &num.as_value_ref());
     result.to_rust()
 }
 
@@ -85,7 +85,7 @@ pub fn make_tuple(cr: &mut OCamlRuntime, fst: String, snd: i64) -> (String, i64)
     ocaml_frame!(cr, (str_root), {
         let num = unsafe { OCaml::of_i64_unchecked(snd) };
         let str = to_ocaml!(cr, fst, str_root);
-        let result = ocaml::make_tuple(cr, &str, &num.as_root());
+        let result = ocaml::make_tuple(cr, &str, &num.as_value_ref());
         result.to_rust()
     })
 }
@@ -100,7 +100,7 @@ pub fn make_some(cr: &mut OCamlRuntime, value: String) -> Option<String> {
 
 pub fn make_ok(cr: &mut OCamlRuntime, value: i64) -> Result<i64, String> {
     let value = unsafe { OCaml::of_i64_unchecked(value) };
-    let result = ocaml::make_ok(cr, &value.as_root());
+    let result = ocaml::make_ok(cr, &value.as_value_ref());
     result.to_rust()
 }
 

--- a/testing/rust-caller/src/lib.rs
+++ b/testing/rust-caller/src/lib.rs
@@ -62,7 +62,7 @@ pub fn increment_bytes(cr: &mut OCamlRuntime, bytes: &str, first_n: usize) -> St
     ocaml_frame!(cr, (bytes_root), {
         let bytes = to_ocaml!(cr, bytes, bytes_root);
         let first_n = unsafe { OCaml::of_i64_unchecked(first_n as i64) };
-        let result = ocaml::increment_bytes(cr, &bytes, &first_n.as_value_ref());
+        let result = ocaml::increment_bytes(cr, bytes, first_n.as_value_ref());
         result.to_rust()
     })
 }
@@ -70,14 +70,14 @@ pub fn increment_bytes(cr: &mut OCamlRuntime, bytes: &str, first_n: usize) -> St
 pub fn increment_ints_list(cr: &mut OCamlRuntime, ints: &Vec<i64>) -> Vec<i64> {
     ocaml_frame!(cr, (root), {
         let ints = to_ocaml!(cr, ints, root);
-        let result = ocaml::increment_ints_list(cr, &ints);
+        let result = ocaml::increment_ints_list(cr, ints);
         result.to_rust()
     })
 }
 
 pub fn twice(cr: &mut OCamlRuntime, num: i64) -> i64 {
     let num = unsafe { OCaml::of_i64_unchecked(num) };
-    let result = ocaml::twice(cr, &num.as_value_ref());
+    let result = ocaml::twice(cr, num.as_value_ref());
     result.to_rust()
 }
 
@@ -85,7 +85,7 @@ pub fn make_tuple(cr: &mut OCamlRuntime, fst: String, snd: i64) -> (String, i64)
     ocaml_frame!(cr, (str_root), {
         let num = unsafe { OCaml::of_i64_unchecked(snd) };
         let str = to_ocaml!(cr, fst, str_root);
-        let result = ocaml::make_tuple(cr, &str, &num.as_value_ref());
+        let result = ocaml::make_tuple(cr, str, num.as_value_ref());
         result.to_rust()
     })
 }
@@ -93,21 +93,21 @@ pub fn make_tuple(cr: &mut OCamlRuntime, fst: String, snd: i64) -> (String, i64)
 pub fn make_some(cr: &mut OCamlRuntime, value: String) -> Option<String> {
     ocaml_frame!(cr, (root), {
         let str = to_ocaml!(cr, value, root);
-        let result = ocaml::make_some(cr, &str);
+        let result = ocaml::make_some(cr, str);
         result.to_rust()
     })
 }
 
 pub fn make_ok(cr: &mut OCamlRuntime, value: i64) -> Result<i64, String> {
     let value = unsafe { OCaml::of_i64_unchecked(value) };
-    let result = ocaml::make_ok(cr, &value.as_value_ref());
+    let result = ocaml::make_ok(cr, value.as_value_ref());
     result.to_rust()
 }
 
 pub fn make_error(cr: &mut OCamlRuntime, value: String) -> Result<i64, String> {
     ocaml_frame!(cr, (root), {
         let result = to_ocaml!(cr, value, root);
-        let result = ocaml::make_error(cr, &result);
+        let result = ocaml::make_error(cr, result);
         result.to_rust()
     })
 }
@@ -115,7 +115,7 @@ pub fn make_error(cr: &mut OCamlRuntime, value: String) -> Result<i64, String> {
 pub fn verify_record_test(cr: &mut OCamlRuntime, record: ocaml::TestRecord) -> String {
     ocaml_frame!(cr, (root), {
         let ocaml_record = to_ocaml!(cr, record, root);
-        let result = ocaml::stringify_record(cr, &ocaml_record);
+        let result = ocaml::stringify_record(cr, ocaml_record);
         result.to_rust()
     })
 }
@@ -123,7 +123,7 @@ pub fn verify_record_test(cr: &mut OCamlRuntime, record: ocaml::TestRecord) -> S
 pub fn verify_variant_test(cr: &mut OCamlRuntime, variant: ocaml::Movement) -> String {
     ocaml_frame!(cr, (root), {
         let ocaml_variant = to_ocaml!(cr, variant, root);
-        let result = ocaml::stringify_variant(cr, &ocaml_variant);
+        let result = ocaml::stringify_variant(cr, ocaml_variant);
         result.to_rust()
     })
 }

--- a/testing/rust-caller/src/lib.rs
+++ b/testing/rust-caller/src/lib.rs
@@ -62,7 +62,7 @@ pub fn increment_bytes(cr: &mut OCamlRuntime, bytes: &str, first_n: usize) -> St
     ocaml_frame!(cr, (bytes_root), {
         let bytes = to_ocaml!(cr, bytes, bytes_root);
         let first_n = unsafe { OCaml::of_i64_unchecked(first_n as i64) };
-        let result = ocaml::increment_bytes(cr, bytes, first_n.as_value_ref());
+        let result = ocaml::increment_bytes(cr, bytes, &first_n);
         result.to_rust()
     })
 }
@@ -77,7 +77,7 @@ pub fn increment_ints_list(cr: &mut OCamlRuntime, ints: &Vec<i64>) -> Vec<i64> {
 
 pub fn twice(cr: &mut OCamlRuntime, num: i64) -> i64 {
     let num = unsafe { OCaml::of_i64_unchecked(num) };
-    let result = ocaml::twice(cr, num.as_value_ref());
+    let result = ocaml::twice(cr, &num);
     result.to_rust()
 }
 
@@ -85,7 +85,7 @@ pub fn make_tuple(cr: &mut OCamlRuntime, fst: String, snd: i64) -> (String, i64)
     ocaml_frame!(cr, (str_root), {
         let num = unsafe { OCaml::of_i64_unchecked(snd) };
         let str = to_ocaml!(cr, fst, str_root);
-        let result = ocaml::make_tuple(cr, str, num.as_value_ref());
+        let result = ocaml::make_tuple(cr, str, &num);
         result.to_rust()
     })
 }
@@ -100,7 +100,7 @@ pub fn make_some(cr: &mut OCamlRuntime, value: String) -> Option<String> {
 
 pub fn make_ok(cr: &mut OCamlRuntime, value: i64) -> Result<i64, String> {
     let value = unsafe { OCaml::of_i64_unchecked(value) };
-    let result = ocaml::make_ok(cr, value.as_value_ref());
+    let result = ocaml::make_ok(cr, &value);
     result.to_rust()
 }
 

--- a/testing/rust-caller/src/lib.rs
+++ b/testing/rust-caller/src/lib.rs
@@ -59,10 +59,10 @@ mod ocaml {
 }
 
 pub fn increment_bytes(cr: &mut OCamlRuntime, bytes: &str, first_n: usize) -> String {
-    ocaml_frame!(cr, (bytes_root, first_n_root), {
+    ocaml_frame!(cr, (bytes_root), {
         let bytes = to_ocaml!(cr, bytes, bytes_root);
-        let first_n = to_ocaml!(cr, first_n as i64, first_n_root);
-        let result = ocaml::increment_bytes(cr, &bytes, &first_n);
+        let first_n = unsafe { OCaml::of_i64_unchecked(first_n as i64) };
+        let result = ocaml::increment_bytes(cr, &bytes, &first_n.as_root());
         result.to_rust()
     })
 }
@@ -76,20 +76,16 @@ pub fn increment_ints_list(cr: &mut OCamlRuntime, ints: &Vec<i64>) -> Vec<i64> {
 }
 
 pub fn twice(cr: &mut OCamlRuntime, num: i64) -> i64 {
-    ocaml_frame!(cr, (root), {
-        let num = unsafe { OCaml::of_i64_unchecked(num) };
-        let num = root.keep(num);
-        let result = ocaml::twice(cr, &num);
-        result.to_rust()
-    })
+    let num = unsafe { OCaml::of_i64_unchecked(num) };
+    let result = ocaml::twice(cr, &num.as_root());
+    result.to_rust()
 }
 
 pub fn make_tuple(cr: &mut OCamlRuntime, fst: String, snd: i64) -> (String, i64) {
-    ocaml_frame!(cr, (num_root, str_root), {
+    ocaml_frame!(cr, (str_root), {
         let num = unsafe { OCaml::of_i64_unchecked(snd) };
-        let num = num_root.keep(num);
         let str = to_ocaml!(cr, fst, str_root);
-        let result = ocaml::make_tuple(cr, &str, &num);
+        let result = ocaml::make_tuple(cr, &str, &num.as_root());
         result.to_rust()
     })
 }
@@ -103,11 +99,9 @@ pub fn make_some(cr: &mut OCamlRuntime, value: String) -> Option<String> {
 }
 
 pub fn make_ok(cr: &mut OCamlRuntime, value: i64) -> Result<i64, String> {
-    ocaml_frame!(cr, (root), {
-        let result = to_ocaml!(cr, value, root);
-        let result = ocaml::make_ok(cr, &result);
-        result.to_rust()
-    })
+    let value = unsafe { OCaml::of_i64_unchecked(value) };
+    let result = ocaml::make_ok(cr, &value.as_root());
+    result.to_rust()
 }
 
 pub fn make_error(cr: &mut OCamlRuntime, value: String) -> Result<i64, String> {


### PR DESCRIPTION
### Changes

Changes to simplify Rust->OCaml calls through the use of a caller-save calling convention, and handling unexpected exceptions with a `panic!`.

- [x] Make `ocaml!` produce functions that expect rooted arguments.
- [x] Make `ocaml!` functions return results directly, instead of wrapped in `Result`. `panic!` on unexpected exceptions.
- [x] ~Implement a way to catch OCaml raised exceptions.~ (Nothing will be done here for now, users will have to resort to `std::panic::catch_unwind`).
- [x] Remove `ocaml_call!` and `ocaml_alloc!` macros.
- [x] Update docs and examples
- [x] Make FromOCaml::from_ocaml take a ref instead of a copy.