### PR TITLE
make 'ocaml' string compatible with strlen function that requires arg…

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -20,7 +20,7 @@ impl OCamlRuntime {
 
     /// Initializes the OCaml runtime.
     pub fn init_persistent() {
-        let arg0 = "ocaml".as_ptr() as *const i8;
+        let arg0 = "ocaml\0".as_ptr() as *const i8;
         let c_args = vec![arg0, core::ptr::null()];
         unsafe { caml_startup(c_args.as_ptr()) }
     }


### PR DESCRIPTION
…s to be null terminated