### PR TITLE
Switch to using Boxroot for root handling

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,9 +8,27 @@ on:
 
 jobs:
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        ocaml-version: ["4.09.1"]
     steps:
       - uses: actions/checkout@v2
+      - name: OCaml/Opam cache
+        id: ocaml-interop-opam-cache
+        uses: actions/cache@v2
+        with:
+          path: "~/.opam"
+          key: ${{ matrix.os }}-${{ matrix.ocaml-version }}
+      - name: Setup OCaml ${{ matrix.ocaml-version }}
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+      - name: Set Opam env
+        run: opam env >> $GITHUB_ENV
+      - name: Add Opam switch to PATH
+        run: opam var bin >> $GITHUB_PATH
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -22,6 +40,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --features=without-ocamlopt
-        env:
-          OCAML_VERSION: 4.09.1
-          OCAML_WHERE_PATH: /ignored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New BoxRoot type for rooted values, implemented by: https://gitlab.com/ocaml-rust/ocaml-boxroot
+- `to_boxroot(cr)` method to `ToOCaml` trait.
+- Support for OCaml tuples of up to 10 elements (until now tuples containing up to 4 elements were supported)
+- `ocaml_interop_setup` and `ocaml_interop_teardown` functions that must be called by OCaml programs before calling Rust code.
+
+### Changed
+
+- Rooted values (both local and global roots) are now handled by BoxRoot.
+
+### Removed
+
+- `ocaml_frame!` macro. BoxRoot replaces the need for opening new local root frames.
+- `to_ocaml!` macro. Without local roots this has no advantage for `value.to_ocaml(cr)`.
+
+
 ## [0.5.3] - 2021-01-26
 
 ### Security

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 features = [ "without-ocamlopt" ]
 
 [dependencies]
-ocaml-sys = "^0.19"
+ocaml-sys = "^0.20"
 ocaml-boxroot-sys = "0.1"
 static_assertions = "1.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ features = [ "without-ocamlopt" ]
 
 [dependencies]
 ocaml-sys = "^0.19"
+ocaml-boxroot-sys = "0.1"
 static_assertions = "1.1.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -9,21 +9,11 @@ _Zinc-iron alloy coating is used in parts that need very good corrosion protecti
 
 **API IS CONSIDERED UNSTABLE AT THE MOMENT AND IS LIKELY TO CHANGE IN THE FUTURE**
 
-[ocaml-interop](https://github.com/simplestaking/ocaml-interop) is an OCaml<->Rust FFI with an emphasis on safety inspired by [caml-oxide](https://github.com/stedolan/caml-oxide) and [ocaml-rs](https://github.com/zshipko/ocaml-rs).
+[ocaml-interop](https://github.com/simplestaking/ocaml-interop) is an OCaml<->Rust FFI with an emphasis on safety inspired by [caml-oxide](https://github.com/stedolan/caml-oxide), [ocaml-rs](https://github.com/zshipko/ocaml-rs) and [CAMLroot](https://arxiv.org/abs/1812.04905).
 
 Read the full documentation [here](https://docs.rs/ocaml-interop/).
 
 Report issues on [Github](https://github.com/simplestaking/ocaml-interop/issues).
-
-## Table of Contents
-
-- [How does it work](#how-does-it-work)
-- [A quick taste](#a-quick-taste)
-- [References and links](#references-and-links)
-
-## How does it work
-
-ocaml-interop, just like [caml-oxide](https://github.com/stedolan/caml-oxide), encodes the invariants of OCaml's garbage collector into the rules of Rust's borrow checker. Any violation of these invariants results in a compilation error produced by Rust's borrow checker.
 
 ## A quick taste
 
@@ -32,7 +22,7 @@ ocaml-interop, just like [caml-oxide](https://github.com/stedolan/caml-oxide), e
 ```rust
 let rust_string = ocaml_string.to_rust();
 // `cr` = OCaml runtime handle
-let new_ocaml_string = to_ocaml!(cr, rust_string);
+let new_ocaml_string = rust_string.to_ocaml(cr);
 ```
 
 ### Convert between Rust and OCaml structs/records
@@ -62,7 +52,7 @@ impl_conv_ocaml_record! {
 // ...
 
 let rust_struct = ocaml_record.to_rust();
-let new_ocaml_record = to_ocaml!(cr, rust_struct);
+let new_ocaml_record = rust_struct.to_ocaml(cr);
 ```
 
 ### Convert between OCaml and Rust variants/enums
@@ -91,7 +81,7 @@ impl_conv_ocaml_variant! {
 // ...
 
 let rust_enum = ocaml_variant.to_rust();
-let new_ocaml_variant = to_ocaml!(cr, rust_enum);
+let new_ocaml_variant = rust_enum.to_ocaml(cr);
 ```
 
 ### Call OCaml functions from Rust
@@ -102,14 +92,15 @@ Callback.register "ocaml_print_endline" print_endline
 ```
 
 ```rust
+// Rust
 ocaml! {
     fn ocaml_print_endline(s: String);
 }
 
 // ...
 
-let ocaml_string = to_ocaml!(cr, "hello OCaml!", root_var);
-ocaml_print_endline(cr, ocaml_string);
+let ocaml_string = "hello OCaml!".to_boxroot(cr);
+ocaml_print_endline(cr, &ocaml_string);
 ```
 
 ### Call Rust functions from OCaml
@@ -117,10 +108,10 @@ ocaml_print_endline(cr, ocaml_string);
 ```rust
 // Rust
 ocaml_export! {
-    pub fn twice_boxed_int(cr, num: OCaml<OCamlInt64>) -> OCaml<OCamlInt64> {
-        let num = num.to_rust();
+    pub fn twice_boxed_int(cr, num: OCamlRef<OCamlInt64>) -> OCaml<OCamlInt64> {
+        let num = num.to_rust(cr);
         let result = num * 2;
-        to_ocaml!(cf, result)
+        result.to_ocaml(cr)
     }
 }
 ```
@@ -143,3 +134,4 @@ let result = rust_twice_boxed_int 123L in
 - [CAMLroot: revisiting the OCaml FFI](https://arxiv.org/abs/1812.04905).
 - [caml-oxide](https://github.com/stedolan/caml-oxide), the code from that paper.
 - [ocaml-rs](https://github.com/zshipko/ocaml-rs), another OCaml<->Rust FFI library.
+- [ocaml-boxroot](https://gitlab.com/ocaml-rust/ocaml-boxroot)

--- a/src/boxroot.rs
+++ b/src/boxroot.rs
@@ -10,6 +10,7 @@ use ocaml_boxroot_sys::{
 
 use crate::{memory::OCamlCell, OCaml, OCamlRef, OCamlRuntime, RawOCaml};
 
+/// `BoxRoot<T>` is a container for a rooted [`OCaml`]`<T>` value.
 pub struct BoxRoot<T: 'static> {
     boxroot: PrimitiveBoxRoot,
     _marker: PhantomData<T>,

--- a/src/boxroot.rs
+++ b/src/boxroot.rs
@@ -1,0 +1,75 @@
+// Copyright (c) SimpleStaking and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::{marker::PhantomData, ops::Deref};
+
+use ocaml_boxroot_sys::{
+    boxroot_create, boxroot_delete, boxroot_get, boxroot_get_ref, boxroot_modify,
+    BoxRoot as PrimitiveBoxRoot,
+};
+
+use crate::{memory::OCamlCell, OCaml, OCamlRef, OCamlRuntime, RawOCaml};
+
+pub struct BoxRoot<T: 'static> {
+    boxroot: PrimitiveBoxRoot,
+    _marker: PhantomData<T>,
+}
+
+impl<T> BoxRoot<T> {
+    /// Creates a new root from an [`OCaml`]`<T>` value.
+    pub fn new(val: OCaml<T>) -> BoxRoot<T> {
+        BoxRoot {
+            boxroot: unsafe { boxroot_create(val.raw) },
+            _marker: PhantomData,
+        }
+    }
+
+    /// Creates a new root from a [`RawOCaml`] value.
+    ///
+    /// # Safety
+    ///
+    /// The type of the value is not validated in any way.
+    pub unsafe fn from_raw(raw: RawOCaml) -> BoxRoot<T> {
+        BoxRoot {
+            boxroot: boxroot_create(raw),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Gets the value stored in this root as an [`OCaml`]`<T>`.
+    pub fn get<'a>(&self, cr: &'a OCamlRuntime) -> OCaml<'a, T> {
+        unsafe { OCaml::new(cr, boxroot_get(self.boxroot)) }
+    }
+
+    /// Gets the value stored in this root as a [`RawOCaml`].
+    ///
+    /// # Safety
+    ///
+    /// The [`RawOCaml`] value obtained may become invalid after the OCaml GC runs,
+    /// and correct usage will not be enforced by the borrow checker.
+    pub unsafe fn get_raw(&self) -> RawOCaml {
+        boxroot_get(self.boxroot)
+    }
+
+    /// Roots the OCaml value `val`, returning an [`OCamlRef`]`<T>`.
+    pub fn keep<'tmp>(&'tmp mut self, val: OCaml<T>) -> OCamlRef<'tmp, T> {
+        unsafe {
+            boxroot_modify(&mut self.boxroot, val.raw);
+            &*(boxroot_get_ref(self.boxroot) as *const OCamlCell<T>)
+        }
+    }
+}
+
+impl<T> Drop for BoxRoot<T> {
+    fn drop(&mut self) {
+        unsafe { boxroot_delete(self.boxroot) }
+    }
+}
+
+impl<T> Deref for BoxRoot<T> {
+    type Target = OCamlCell<T>;
+
+    fn deref(&self) -> OCamlRef<T> {
+        unsafe { &*(boxroot_get_ref(self.boxroot) as *const OCamlCell<T>) }
+    }
+}

--- a/src/compile_fail_tests.rs
+++ b/src/compile_fail_tests.rs
@@ -7,57 +7,12 @@
 /// ```compile_fail
 /// # use ocaml_interop::*;
 /// # let cr = &mut OCamlRuntime::init();
-/// ocaml_frame!(cr, (root), {
 /// let arg1: OCaml<String> = "test".to_owned().to_ocaml(cr);
 /// let arg2: OCaml<String> = "test".to_owned().to_ocaml(cr);
-/// let arg1_root = root.keep(arg1);
+/// let arg1_rust: String = arg1.to_rust();
 /// # ()
-/// });
 /// ```
 pub struct LivenessFailureCheck;
-
-// Check that OCamlRawRoot values cannot escape the frame that created them.
-// Must fail with:
-// error[E0716]: temporary value dropped while borrowed
-/// ```compile_fail
-/// # use ocaml_interop::*;
-/// # ocaml! { pub fn ocaml_function(arg1: String) -> String; }
-/// # let cr = &mut OCamlRuntime::init();
-/// let escaped = ocaml_frame!(cr, (rootvar), {
-///     rootvar
-/// });
-/// # ()
-/// ```
-pub struct OCamlRawRootEscapeFailureCheck;
-
-// Check that OCamlRef values cannot escape the frame that created the associated root.
-// Must fail with:
-// error[E0716]: temporary value dropped while borrowed
-/// ```compile_fail
-/// # use ocaml_interop::*;
-/// # ocaml! { pub fn ocaml_function(arg1: String) -> String; }
-/// # let cr = &mut OCamlRuntime::init();
-/// let escaped = ocaml_frame!(cr, (rootvar), {
-///     let arg1: OCaml<String> = "test".to_owned().to_ocaml(cr);
-///     let arg1_root = rootvar.keep(arg1);
-///     arg1_root
-/// });
-/// # ()
-/// ```
-pub struct OCamlRootEscapeFailureCheck;
-
-// Check that roots created from immediate values cannot escape.
-// Must fail with:
-// error[E0597]: `ocaml_n` does not live long enough
-/// ```compile_fail
-/// # use ocaml_interop::*;
-/// let escaped = {
-///     let ocaml_n: OCaml<'static, OCamlInt> = unsafe { OCaml::of_i64_unchecked(10) };
-///     ocaml_n.as_value_ref()
-/// };
-/// # ()
-/// ```
-pub struct OCamlImmediateRootEscapeFailureCheck;
 
 // Checks that OCamlRef values made from non-immediate OCaml values cannot be used
 // as if they were references to rooted values.
@@ -67,7 +22,7 @@ pub struct OCamlImmediateRootEscapeFailureCheck;
 /// # use ocaml_interop::*;
 /// # ocaml! { fn ocaml_function(arg1: String) -> String; }
 /// # fn test(cr: &'static mut OCamlRuntime) {
-/// let arg1: OCaml<String> = to_ocaml!(cr, "test");
+/// let arg1: OCaml<String> = "test".to_ocaml(cr);
 /// let _ = ocaml_function(cr, &arg1);
 /// }
 /// ```

--- a/src/conv/from_ocaml.rs
+++ b/src/conv/from_ocaml.rs
@@ -104,11 +104,7 @@ where
     A: FromOCaml<OCamlA>,
 {
     fn from_ocaml(v: OCaml<Option<OCamlA>>) -> Self {
-        if let Some(value) = v.to_option() {
-            Some(A::from_ocaml(value))
-        } else {
-            None
-        }
+        v.to_option().map(A::from_ocaml)
     }
 }
 

--- a/src/conv/from_ocaml.rs
+++ b/src/conv/from_ocaml.rs
@@ -108,49 +108,6 @@ where
     }
 }
 
-unsafe impl<A, B, OCamlA, OCamlB> FromOCaml<(OCamlA, OCamlB)> for (A, B)
-where
-    A: FromOCaml<OCamlA>,
-    B: FromOCaml<OCamlB>,
-{
-    fn from_ocaml(v: OCaml<(OCamlA, OCamlB)>) -> Self {
-        (A::from_ocaml(v.fst()), B::from_ocaml(v.snd()))
-    }
-}
-
-unsafe impl<A, B, C, OCamlA, OCamlB, OCamlC> FromOCaml<(OCamlA, OCamlB, OCamlC)> for (A, B, C)
-where
-    A: FromOCaml<OCamlA>,
-    B: FromOCaml<OCamlB>,
-    C: FromOCaml<OCamlC>,
-{
-    fn from_ocaml(v: OCaml<(OCamlA, OCamlB, OCamlC)>) -> Self {
-        (
-            A::from_ocaml(v.fst()),
-            B::from_ocaml(v.snd()),
-            C::from_ocaml(v.tuple_3()),
-        )
-    }
-}
-
-unsafe impl<A, B, C, D, OCamlA, OCamlB, OCamlC, OCamlD> FromOCaml<(OCamlA, OCamlB, OCamlC, OCamlD)>
-    for (A, B, C, D)
-where
-    A: FromOCaml<OCamlA>,
-    B: FromOCaml<OCamlB>,
-    C: FromOCaml<OCamlC>,
-    D: FromOCaml<OCamlD>,
-{
-    fn from_ocaml(v: OCaml<(OCamlA, OCamlB, OCamlC, OCamlD)>) -> Self {
-        (
-            A::from_ocaml(v.fst()),
-            B::from_ocaml(v.snd()),
-            C::from_ocaml(v.tuple_3()),
-            D::from_ocaml(v.tuple_4()),
-        )
-    }
-}
-
 unsafe impl<A, OCamlA> FromOCaml<OCamlList<OCamlA>> for Vec<A>
 where
     A: FromOCaml<OCamlA>,
@@ -166,3 +123,72 @@ where
         vec
     }
 }
+
+// Tuples
+
+macro_rules! tuple_from_ocaml {
+    ($($accessor:ident: $t:ident => $ot:ident),+) => {
+        unsafe impl<$($t),+, $($ot: 'static),+> FromOCaml<($($ot),+)> for ($($t),+)
+        where
+            $($t: FromOCaml<$ot>),+
+        {
+            fn from_ocaml(v: OCaml<($($ot),+)>) -> Self {
+                ($($t::from_ocaml(v.$accessor())),+)
+
+            }
+        }
+    };
+}
+
+tuple_from_ocaml!(
+    fst: OCamlA => A,
+    snd: OCamlB => B);
+tuple_from_ocaml!(
+    fst: OCamlA => A,
+    snd: OCamlB => B,
+    tuple_3: OCamlC => C);
+tuple_from_ocaml!(
+    fst: OCamlA => A,
+    snd: OCamlB => B,
+    tuple_3: OCamlC => C,
+    tuple_4: OCamlD => D);
+tuple_from_ocaml!(
+    fst: OCamlA => A,
+    snd: OCamlB => B,
+    tuple_3: OCamlC => C,
+    tuple_4: OCamlD => D,
+    tuple_5: OCamlE => E);
+tuple_from_ocaml!(
+    fst: OCamlA => A,
+    snd: OCamlB => B,
+    tuple_3: OCamlC => C,
+    tuple_4: OCamlD => D,
+    tuple_5: OCamlE => E,
+    tuple_6: OCamlF => F);
+tuple_from_ocaml!(
+    fst: OCamlA => A,
+    snd: OCamlB => B,
+    tuple_3: OCamlC => C,
+    tuple_4: OCamlD => D,
+    tuple_5: OCamlE => E,
+    tuple_6: OCamlF => F,
+    tuple_7: OCamlG => G);
+tuple_from_ocaml!(
+    fst: OCamlA => A,
+    snd: OCamlB => B,
+    tuple_3: OCamlC => C,
+    tuple_4: OCamlD => D,
+    tuple_5: OCamlE => E,
+    tuple_6: OCamlF => F,
+    tuple_7: OCamlG => G,
+    tuple_8: OCamlH => H);
+tuple_from_ocaml!(
+    fst: OCamlA => A,
+    snd: OCamlB => B,
+    tuple_3: OCamlC => C,
+    tuple_4: OCamlD => D,
+    tuple_5: OCamlE => E,
+    tuple_6: OCamlF => F,
+    tuple_7: OCamlG => G,
+    tuple_8: OCamlH => H,
+    tuple_9: OCamlI => I);

--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -175,15 +175,6 @@ where
     A: ToOCaml<OCamlA>,
 {
     fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlList<OCamlA>> {
-        (&self).to_ocaml(cr)
-    }
-}
-
-unsafe impl<A, OCamlA: 'static> ToOCaml<OCamlList<OCamlA>> for &Vec<A>
-where
-    A: ToOCaml<OCamlA>,
-{
-    fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlList<OCamlA>> {
         let mut result = BoxRoot::new(OCaml::nil());
         for elt in self.iter().rev() {
             let ov = elt.to_boxroot(cr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,16 +7,15 @@
 //!
 //! **API IS CONSIDERED UNSTABLE AT THE MOMENT AND IS LIKELY TO CHANGE IN THE FUTURE**
 //!
-//! [ocaml-interop](https://github.com/simplestaking/ocaml-interop) is an OCaml<->Rust FFI with an emphasis on safety inspired by [caml-oxide](https://github.com/stedolan/caml-oxide) and [ocaml-rs](https://github.com/zshipko/ocaml-rs).
+//! [ocaml-interop](https://github.com/simplestaking/ocaml-interop) is an OCaml<->Rust FFI with an emphasis
+//! on safety inspired by [caml-oxide](https://github.com/stedolan/caml-oxide),
+//! [ocaml-rs](https://github.com/zshipko/ocaml-rs) and [CAMLroot](https://arxiv.org/abs/1812.04905).
 //!
 //! ## Table of Contents
 //!
-//! - [How does it work](#how-does-it-work)
 //! - [Usage](#usage)
-//!   * [Rules](#rules)
-//!     + [Rule 1: The OCaml runtime handle](#rule-1-the-ocaml-runtime-handle)
-//!     + [Rule 2: Liveness of OCaml values and rooting](#rule-2-liveness-of-ocaml-values-and-rooting)
-//!     + [Rule 3: Liveness and scope of OCaml roots](#rule-3-liveness-and-scope-ocaml-roots)
+//!   * [The OCaml runtime handle](#the-ocaml-runtime-handle)
+//!   * [OCaml value representation](#ocaml-value-representation)
 //!   * [Converting between OCaml and Rust data](#converting-between-ocaml-and-rust-data)
 //!     + [`FromOCaml` trait](#fromocaml-trait)
 //!     + [`ToOCaml` trait](#toocaml-trait)
@@ -26,77 +25,30 @@
 //!   * [Calling into Rust from OCaml](#calling-into-rust-from-ocaml)
 //! - [References and links](#references-and-links)
 //!
-//! ## How does it work
-//!
-//! ocaml-interop, just like [caml-oxide](https://github.com/stedolan/caml-oxide), encodes the invariants of OCaml's garbage collector into the rules of Rust's borrow checker. Any violation of these invariants results in a compilation error produced by Rust's borrow checker.
-//!
 //! ## Usage
 //!
-//! ### Rules
+//! ### The OCaml runtime handle
 //!
-//! There are a few rules that have to be followed when calling into the OCaml runtime:
+//! The OCaml runtime handle is represented by a [`OCamlRuntime`] value. To be able to use of the capabilities
+//! offered by the OCaml runtime, access to this handle is required. The handle is first obtained when calling
+//! [`OCamlRuntime::init`] to initialize the OCaml runtime. Rust functions called form OCaml will also receive
+//! a `&mut OCamlRuntime` as their first argument.
 //!
-//! #### Rule 1: The OCaml runtime handle
+//! This OCaml runtime handle must belong to a single thread, and passed around (moved or as a `&mut` reference)
+//! to any code that needs access to the OCaml runtime.
 //!
-//! To interact with the OCaml runtime (be it reading, mutating or allocating values, or to call functions) a reference to the OCaml runtime handle must be available.
-//! Any function that interacts with the OCaml runtime takes as a first argument a reference to the OCaml runtime handle.
+//! Un-rooted non-immediate OCaml values have a lifetime associated to the OCaml runtime handle, and will become
+//! stale once the OCaml runtime is mutably borrowed.
 //!
-//! #### Rule 2: Liveness of OCaml values and rooting
+//! ### OCaml value representation
 //!
-//! Rust references to OCaml values become stale after calls into the OCaml runtime and cannot be used again. This is enforced by Rust's borrow checker.
+//! OCaml values are exposed to Rust using three types:
 //!
-//! To have OCaml values survive across calls into the OCaml runtime, they have to be rooted, and then recovered from a root.
-//!
-//! Rooting is only possible inside `ocaml_frame!` blocks, which initialize a list of root variables that can be used to root OCaml values.
-//!
-//! #### Rule 3: Liveness and scope of OCaml roots
-//!
-//! OCaml roots are only valid inside the [`ocaml_frame!`] that instantiated them, and cannot escape this scope.
-//!
-//! Example (fails to compile):
-//!
-//! ```rust,compile_fail
-//! # use ocaml_interop::*;
-//! # ocaml! {
-//! #     fn ocaml_function(arg1: String) -> String;
-//! #     fn another_ocaml_function(arg: String);
-//! # }
-//! # let a_string = "string";
-//! # let arg1 = "arg1";
-//! # let cr = unsafe { &mut OCamlRuntime::recover_handle() };
-//! let escape = ocaml_frame!(cr, (arg1_root), {
-//!     let arg1 = arg1.to_boxroot(cr);
-//!     let arg1_root = arg1_root.keep(arg1);
-//!     let result = ocaml_function(cr, arg1_root, /* ..., argN */);
-//!     let s: String = result.to_rust();
-//!     // ...
-//!     arg1_root
-//! });
-//! ```
-//!
-//! In the above example `arg1_root` cannot escape the [`ocaml_frame!`] scope, Rust's borrow checker will complain:
-//!
-//! ```text,no_run
-//! error[E0716]: temporary value dropped while borrowed
-//!   --> src/lib.rs:64:14
-//!    |
-//!    |   let escape = ocaml_frame!(cr, (arg1_root), {
-//!    |  _____------___^
-//!    | |     |
-//!    | |     borrow later stored here
-//!    | |     let arg1 = arg1.to_boxroot(cr);
-//!    | |     let arg1_root = arg1_root.keep(arg1);
-//!    | |     let result = ocaml_function(cr, arg1_root, /* ..., argN */);
-//! ...  |
-//!    | |     arg1_root
-//!    | | });
-//!    | |  ^
-//!    | |  |
-//!    | |__creates a temporary which is freed while still in use
-//!    |    temporary value is freed at the end of this statement
-//! ```
-//!
-//! A similar error would happen if a root-variable escaped the frame scope.
+//! - [`OCaml`]`<'gc, T>` is the representation of OCaml values in Rust. These values become stale
+//!   after calls into the OCaml runtime and must be re-referenced.
+//! - [`BoxRoot`]`<T>` is a container for an [`OCaml`]`<T>` value that is rooted and tracked by
+//!   OCaml's Garbage Collector.
+//! - [`OCamlRef`]`<'a, T>` is a reference to an [`OCaml`]`<T>` value that may or may not be rooted.
 //!
 //! ### Converting between OCaml and Rust data
 //!
@@ -104,35 +56,49 @@
 //!
 //! The [`FromOCaml`] trait implements conversion from OCaml values into Rust values, using the `from_ocaml` function.
 //!
-//! [`OCaml`]`<T>` values have a `to_rust()` method that is usually more convenient than `Type::from_ocaml(ocaml_value)`, and works for any combination that implements the `FromOCaml` trait.
+//! [`OCaml`]`<T>` values have a `to_rust()` method that is usually more convenient than `Type::from_ocaml(ocaml_value)`,
+//! and works for any combination that implements the `FromOCaml` trait.
 //!
 //! [`OCamlRef`]`<T>` values have a `to_rust(cr)` that needs an [`OCamlRuntime`] reference to be passed to it.
 //!
 //! #### [`ToOCaml`] trait
 //!
-//! The [`ToOCaml`] trait implements conversion from Rust values into OCaml values, using the `to_ocaml` method. It takes a single parameter that must be a `&mut OCamlRuntime`.
-//!
-//! A more convenient way to convert Rust values into OCaml values is provided by the [`to_ocaml!`] macro that accepts a root variable as an optional third argument to return a root containing the value.
+//! The [`ToOCaml`] trait implements conversion from Rust values into OCaml values, using the `to_ocaml` method.
+//! It takes a single parameter that must be a `&mut OCamlRuntime`.
 //!
 //! ### Calling convention
 //!
-//! There are two possible calling conventions in regards to rooting, one with *callee rooted arguments*, and another with *caller rooted arguments*.
+//! There are two possible calling conventions in regards to rooting, one with *callee rooted arguments*,
+//! and another with *caller rooted arguments*.
 //!
 //! #### Callee rooted arguments calling convention
 //!
-//! With this calling convention, values that are arguments to a function call are passed directly. Functions that receive arguments are responsible for rooting them. This is how OCaml's C API and `ocaml-interop` versions before `0.5.0` work.
+//! With this calling convention, values that are arguments to a function call are passed directly.
+//! Functions that receive arguments are responsible for rooting them. This is how OCaml's C API and
+//! `ocaml-interop` versions before `0.5.0` work.
 //!
 //! #### Caller rooted arguments calling convention
 //!
-//! With this calling convention, values that are arguments to a function call must be rooted by the caller. Then instead of the value, it is the root pointing to the value that is passed as an argument. This is how `ocaml-interop` works starting with version `0.5.0`.
+//! With this calling convention, values that are arguments to a function call must be rooted by the caller.
+//! Then instead of the value, it is the root pointing to the value that is passed as an argument.
+//! This is how `ocaml-interop` works starting with version `0.5.0`.
 //!
-//! When a Rust function is called from OCaml, it will receive arguments as `OCamlRef<T>` values, and when a OCaml function is called from Rust, arguments will be passed as `OCamlRef<T>` values.
+//! When a Rust function is called from OCaml, it will receive arguments as [`OCamlRef`]`<T>` values,
+//! and when a OCaml function is called from Rust, arguments will be passed as [`OCamlRef`]`<T>` values.
+//!
+//! #### Return values
+//!
+//! When an OCaml function is called from Rust, the return value is a [`BoxRoot`]`<T>`.
+//!
+//! Rust functions that are meant to be called from OCaml must return [`OCaml`]`<T>` values.
 //!
 //! ### OCaml exceptions
 //!
 //! If an OCaml function called from Rust raises an exception, this will result in a panic.
 //!
-//! OCaml functions meant to be called from Rust should not raise exceptions to signal errors, but instead return `result` or `option` values, which can then be mapped into `Result` and `Option` values in Rust.
+//! OCaml functions meant to be called from Rust should not raise exceptions to signal errors,
+//! but instead return `result` or `option` values, which can then be mapped into `Result` and
+//! `Option` values in Rust.
 //!
 //! ### Calling into OCaml from Rust
 //!
@@ -156,15 +122,15 @@
 //!
 //! To be able to call these from Rust, there are a few things that need to be done:
 //!
-//! - The OCaml runtime has to be initialized. If the driving program is a Rust application, it has to be done explicitly by doing `let runtime = OCamlRuntime::init()`, but if the driving program is an OCaml application, this is not required.
+//! - Rust-driven programs must initialize the OCaml runtime.
+//! - OCaml-driven programs must call the `ocaml_interop_setup` function.
 //! - Functions that were exported from the OCaml side with `Callback.register` have to be declared using the [`ocaml!`] macro.
-//! - Before the program exist, or once the OCaml runtime is not required anymore, it has to be de-initialized by calling the `shutdown()` method on the OCaml runtime handle.
 //!
 //! ### Example
 //!
 //! ```rust,no_run
 //! use ocaml_interop::{
-//!     BoxRoot, FromOCaml, OCaml, OCamlRef, ToOCaml, OCamlRuntime
+//!     BoxRoot, FromOCaml, OCaml, OCamlInt, OCamlRef, ToOCaml, OCamlRuntime
 //! };
 //!
 //! // To call an OCaml function, it first has to be declared inside an `ocaml!` macro block:
@@ -173,10 +139,21 @@
 //!
 //!     ocaml! {
 //!         // OCaml: `val increment_bytes: bytes -> int -> bytes`
-//!         // registered with `Callback.register "increment_bytes" increment_bytes`
+//!         // registered with `Callback.register "increment_bytes" increment_bytes`.
+//!         // In Rust, this will be exposed as:
+//!         //     pub fn increment_bytes(
+//!         //         _: &mut OCamlRuntime,
+//!         //         bytes: OCamlRef<String>,
+//!         //         first_n: OCamlRef<OCamlInt>,
+//!         //     ) -> BoxRoot<String>;
 //!         pub fn increment_bytes(bytes: String, first_n: OCamlInt) -> String;
 //!         // OCaml: `val twice: int -> int`
-//!         // registered with `Callback.register "twice" twice`
+//!         // registered with `Callback.register "twice" twice`.
+//!         // In Rust this will be exposed as:
+//!         //     pub fn twice(
+//!         //         _: &mut OCamlRuntime,
+//!         //         num: OCamlRef<OCamlInt>,
+//!         //     ) -> BoxRoot<OCamlInt>;
 //!         pub fn twice(num: OCamlInt) -> OCamlInt;
 //!     }
 //! }
@@ -188,53 +165,39 @@
 //!     first_n: usize,
 //! ) -> (String, String) {
 //!     // Any calls into the OCaml runtime takes as input a `&mut` reference to an `OCamlRuntime`
-//!     // value that is obtained as the result of initializing the OCaml runtime.
-//!     // If rooting of OCaml values is needed, a new frame has to be opened by using the
-//!     // `ocaml_frame!` macro.
-//!     // The first argument to the macro is a reference to an `OCamlRuntime`, followed by a
-//!     // list of "root variables" (more on this later). The last argument
-//!     // is the block of code that will run inside that frame.
-//!     // The `ToOCaml` trait provides the `to_ocaml` method to convert Rust
+//!     // value that is obtained as the result of initializing the OCaml runtime with the
+//!     // `OCamlRuntime::init()` call.
+//!     // The `ToOCaml` trait provides the `to_ocaml` and `to_boxroot` methods to convert Rust
 //!     // values into OCaml values.
-//!     let ocaml_bytes1: BoxRoot<String> = bytes1.to_boxroot(cr);
-//!
-//!     // Same as above. Here the convenience macro [`to_ocaml!`] is used.
-//!     // It works like `value.to_boxroot(cr)`, but has an optional third argument that
-//!     // can be a root variable to perform the rooting.
-//!     // This variation returns an `OCamlRef` value instead of an `OCaml` one.
-//!     let bytes2_root = bytes2.to_boxroot(cr);
+//!     // Here `to_boxroot` is used to produce OCaml values that are already rooted.
+//!     let ocaml_bytes1_rooted: BoxRoot<String> = bytes1.to_boxroot(cr);
+//!     let ocaml_bytes2_rooted = bytes2.to_boxroot(cr);
 //!
 //!     // Rust `i64` integers can be converted into OCaml fixnums with `OCaml::of_i64`
 //!     // and `OCaml::of_i64_unchecked`.
 //!     // Such conversion doesn't require any allocation on the OCaml side, and doesn't
-//!     // invalidate other `OCaml<T>` values.
-//!     let ocaml_first_n = unsafe { OCaml::of_i64_unchecked(first_n as i64) };
+//!     // invalidate other `OCaml<T>` values. In addition, these immediate values require rooting.
+//!     let ocaml_first_n: OCaml<'static, OCamlInt> =
+//!         unsafe { OCaml::of_i64_unchecked(first_n as i64) };
 //!
 //!     // Any OCaml function (declared above in a `ocaml!` block) can be called as a regular
 //!     // Rust function, by passing a `&mut OCamlRuntime` as the first argument, followed by
 //!     // the rest of the arguments declared for that function.
-//!     // Arguments to these functions must be references to roots: `OCamlRef<T>`
+//!     // Arguments to these functions must be `OCamlRef<T>` values. These are the result of
+//!     // dereferencing `OCaml<T>` and `BoxRoot<T>` values.
 //!     let result1 = ocaml_funcs::increment_bytes(
-//!         cr,             // &mut OCamlRuntime
-//!         &ocaml_bytes1,    // OCamlRef<String>
-//!         // Immediate OCaml values, such as ints and books have an as_value_ref() method
-//!         // that can be used to simulate rooting.
-//!         &ocaml_first_n, // OCamlRef<OCamlInt>
+//!         cr,                   // &mut OCamlRuntime
+//!         &ocaml_bytes1_rooted, // OCamlRef<String>
+//!         &ocaml_first_n,       // OCamlRef<OCamlInt>
 //!     );
 //!
-//!     // Perform the conversion of the OCaml result value into a
-//!     // Rust value while the reference is still valid because the
-//!     // call that follows will invalidate it.
-//!     // Alternatively, the result of `rootvar.keep(result1)` could be used
-//!     // to be able to reference the value later through an `OCamlRef` value.
-//!     let new_bytes1: String = result1.to_rust(cr);
 //!     let result2 = ocaml_funcs::increment_bytes(
 //!         cr,
-//!         &bytes2_root,
+//!         &ocaml_bytes2_rooted,
 //!         &ocaml_first_n,
 //!     );
 //!
-//!     (new_bytes1, result2.to_rust(cr))
+//!     (result1.to_rust(cr), result2.to_rust(cr))
 //! }
 //!
 //! fn twice(cr: &mut OCamlRuntime, num: usize) -> usize {
@@ -264,6 +227,8 @@
 //! ### Calling into Rust from OCaml
 //!
 //! To be able to call a Rust function from OCaml, it has to be defined in a way that exposes it to OCaml. This can be done with the [`ocaml_export!`] macro.
+//!
+//! If the program is OCaml-driven, the `ocaml_interop_setup` function must be called from OCaml first, and the `ocaml_interop_teardown` function must be called at the end of the OCaml program.
 //!
 //! #### Example
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -975,42 +975,6 @@ macro_rules! ocaml_unpack_polymorphic_variant {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! repeat_slice {
-    (@expr $value:expr;
-     @accum [$($accum:expr),+];
-     @rest) => {
-         [$($accum),+]
-     };
-
-    (@expr $value:expr;
-     @accum [$($accum:expr),+];
-     @rest $_v1:ident $_v2:ident $_v3:ident $_v4:ident $_v5:ident $($vars:ident)*) => {
-        $crate::repeat_slice!(
-            @expr $value;
-            @accum [$value, $value, $value, $value, $value, $($accum),+];
-            @rest $($vars)*)
-    };
-
-    (@expr $value:expr;
-        @accum [$($accum:expr),+];
-        @rest $_v1:ident $($vars:ident)*) => {
-
-        $crate::repeat_slice!(
-            @expr $value;
-            @accum [$value, $($accum),+];
-            @rest $($vars)*)
-    };
-
-    ($value:expr, $field:ident $($vars:ident)*) => {
-        $crate::repeat_slice!(
-            @expr $value;
-            @accum [$value];
-            @rest $($vars)*)
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
 macro_rules! count_fields {
     () => {0usize};
     ($_f1:ident $_f2:ident $_f3:ident $_f4:ident $_f5:ident $($fields:ident)*) => {
@@ -1229,27 +1193,6 @@ macro_rules! ocaml_closure_reference {
             OC.unwrap_or_else(|| panic!("OCaml closure with name '{}' not registered", NAME))
         };
     };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! gcmark_result {
-    ($cr:ident, $obj:expr) => {
-        match $obj {
-            Ok(t) => Ok(t.mark($cr).eval($cr)),
-            Err(e) => Err(e),
-        }
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! default_to_ocaml_unit {
-    // No return value, default to unit
-    () => ($crate::OCaml<()>);
-
-    // Return value specified
-    ($rtyp:ty) => ($rtyp);
 }
 
 #[doc(hidden)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,50 +4,6 @@
 #[cfg(doc)]
 use crate::*;
 
-/// Opens a new frame inside of which OCaml values can be rooted to have them tracked by the GC.
-///
-/// The first argument to this macro must a reference to an OCaml runtime handle.
-///
-/// The second argument is a list of "root variables" to reserve. These variables can
-/// be used to "root" [`OCaml`] values to obtain [`OCamlRef`] values that can be used
-/// to recover stale references to [`OCaml`] values after calls to the OCaml runtime.
-///
-/// # Examples
-///
-/// The following example reserves two root variables which are consumed to create two [`OCamlRef`]
-/// values later used to retrieve two OCaml values after performing allocations through the OCaml runtime:
-///
-/// ```
-/// # use ocaml_interop::*;
-/// # ocaml! {
-/// #    fn print_endline(s: String);
-/// # }
-/// # fn ocaml_frame_macro_example(cr: &mut OCamlRuntime) {
-///     ocaml_frame!(cr, (hello_ocaml, bye_ocaml), {
-///         let hello_ocaml = to_ocaml!(cr, "hello OCaml!", hello_ocaml);
-///         let bye_ocaml = to_ocaml!(cr, "bye OCaml!", bye_ocaml);
-///         print_endline(cr, hello_ocaml);
-///         print_endline(cr, bye_ocaml);
-///     });
-/// # }
-/// ```
-#[macro_export]
-macro_rules! ocaml_frame {
-   ($cr:ident, ($($rootvar:ident),+ $(,)?), $body:block) => {{
-        let mut frame = $cr.open_frame();
-        let local_roots = $crate::repeat_slice!(::core::cell::UnsafeCell::new($crate::internal::UNIT), $($rootvar)+);
-        let gc = frame.initialize(&local_roots);
-        $(
-            let $rootvar = unsafe { &mut $crate::internal::OCamlRawRoot::reserve(gc) };
-        )+
-        $body
-    }};
-
-    ($($t:tt)*) => {
-        compile_error!("Invalid `ocaml_frame!` syntax. Must be `ocaml_frame!(cr, (vars, ...), { body-block })`.")
-    };
-}
-
 /// Declares OCaml functions.
 ///
 /// `ocaml! { pub fn ocaml_name(arg1: Typ1, ...) -> Ret_typ; ... }` declares a function that has been
@@ -58,7 +14,7 @@ macro_rules! ocaml_frame {
 /// When invoking one of these functions, the first argument must be a `&mut OCamlRuntime`,
 /// and the remaining arguments `OCamlRef<ArgT>`.
 ///
-/// The return value is an `OCaml<RetType>`.
+/// The return value is a `BoxRoot<RetType>`.
 ///
 /// Calls that raise an OCaml exception will `panic!`.
 ///
@@ -88,9 +44,9 @@ macro_rules! ocaml {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
             $arg: $crate::OCamlRef<$typ>,
-        ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
+        ) -> $crate::BoxRoot<$crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
-            closure.call(cr, $arg)
+            $crate::BoxRoot::new(closure.call(cr, $arg))
         }
 
         $crate::ocaml!($($t)*);
@@ -104,9 +60,9 @@ macro_rules! ocaml {
             cr: &'a mut $crate::OCamlRuntime,
             $arg1: $crate::OCamlRef<$typ1>,
             $arg2: $crate::OCamlRef<$typ2>,
-        ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
+        ) -> $crate::BoxRoot<$crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
-            closure.call2(cr, $arg1, $arg2)
+            $crate::BoxRoot::new(closure.call2(cr, $arg1, $arg2))
         }
 
         $crate::ocaml!($($t)*);
@@ -122,9 +78,9 @@ macro_rules! ocaml {
             $arg1: $crate::OCamlRef<$typ1>,
             $arg2: $crate::OCamlRef<$typ2>,
             $arg3: $crate::OCamlRef<$typ3>,
-        ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
+        ) -> $crate::BoxRoot<$crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
-            closure.call3(cr, $arg1, $arg2, $arg3)
+            $crate::BoxRoot::new(closure.call3(cr, $arg1, $arg2, $arg3))
         }
 
         $crate::ocaml!($($t)*);
@@ -136,9 +92,9 @@ macro_rules! ocaml {
         $vis fn $name<'a>(
             cr: &'a mut $crate::OCamlRuntime,
             $($arg: $crate::OCamlRef<$typ>),+
-    ) -> $crate::OCaml<'a, $crate::default_to_unit!($($rtyp)?)> {
+    ) -> $crate::BoxRoot<$crate::default_to_unit!($($rtyp)?)> {
             $crate::ocaml_closure_reference!(closure, $name);
-            closure.call_n(cr, &mut [$(unsafe { $arg.get_raw() }),+])
+            $crate::BoxRoot::new(closure.call_n(cr, &mut [$(unsafe { $arg.get_raw() }),+]))
         }
 
         $crate::ocaml!($($t)*);
@@ -147,14 +103,11 @@ macro_rules! ocaml {
 
 /// Defines Rust functions callable from OCaml.
 ///
-/// The first argument in these functions declarations is the same as in the [`ocaml_frame!`] macro.
+/// The first argument in these functions declarations is a name to bind a `&mut OCamlRuntme`.
 ///
 /// Arguments and return values must be of type [`OCaml`]`<T>`, or `f64` in the case of unboxed floats.
 ///
 /// The return type defaults to unit when omitted.
-///
-/// The body of the function has an implicit [`ocaml_frame!`] wrapper, with the lifetimes of every [`OCaml`]`<T>`
-/// argument bound to the lifetime of the variable bound to the function's OCaml frame GC handle.
 ///
 /// # Examples
 ///
@@ -214,7 +167,6 @@ macro_rules! ocaml_export {
         $crate::expand_exported_function!(
             @name $name
             @cr $cr
-            @roots { }
             @final_args { }
             @proc_args { $($args)*, }
             @return { f64 }
@@ -235,7 +187,6 @@ macro_rules! ocaml_export {
         $crate::expand_exported_function!(
             @name $name
             @cr $cr
-            @roots { }
             @final_args { }
             @proc_args { $($args)*, }
             @return { $($rtyp)? }
@@ -256,54 +207,6 @@ macro_rules! ocaml_export {
     } => {
         compile_error!("Rust->OCaml exported functions must include an identifier for the OCaml runtime handle followed by at least one argument");
     }
-}
-
-/// Converts Rust values into OCaml values.
-///
-/// In `to_ocaml!(cr, value)`, `cr` is an OCaml Runtime handle, and `value` is
-/// a Rust value of a type that implements the [`ToOCaml`] trait. The resulting
-/// value's lifetime is bound to `cr`'s borrow.
-///
-/// An alternative form accepts a third "root variable" argument: `to_ocaml!(cr, value, rootvar)`.
-/// `rootvar` is one of the "root variables" declared when opening an [`ocaml_frame!`].
-/// This variant consumes `rootvar` returns an [`OCamlRef`] value instead of an [`OCaml`] one.
-///
-/// # Examples
-///
-/// ```
-/// # use ocaml_interop::*;
-/// # fn to_ocaml_macro_example(cr: &mut OCamlRuntime) {
-///     let ocaml_string: OCaml<String> = to_ocaml!(cr, "hello OCaml!");
-///     // ...
-///     # ()
-/// # }
-/// ```
-///
-/// Variant:
-///
-/// ```
-/// # use ocaml_interop::*;
-/// # fn to_ocaml_macro_example(cr: &mut OCamlRuntime) {
-///     ocaml_frame!(cr, (rootvar), {
-///         let ocaml_string_ref: OCamlRef<String> = to_ocaml!(cr, "hello OCaml!", rootvar);
-///         // ...
-///         # ()
-///     });
-/// # }
-/// ```
-#[macro_export]
-macro_rules! to_ocaml {
-    ($cr:ident, $obj:expr, $rootvar:ident) => {
-        $rootvar.keep($crate::to_ocaml!($cr, $obj))
-    };
-
-    ($cr:ident, $obj:expr) => {
-        ($obj).to_ocaml($cr)
-    };
-
-    ($($t:tt)*) => {
-        compile_error!("Incorrect `to_ocaml!` syntax. Must be `to_ocaml!(cr, expr[, rootvar])`")
-    };
 }
 
 /// Implements conversion between a Rust struct and an OCaml record.
@@ -396,7 +299,8 @@ macro_rules! impl_conv_ocaml_variant {
 /// // NOTE: What is important is the order of the fields, not their names.
 ///
 /// # fn unpack_record_example(cr: &mut OCamlRuntime) {
-/// let ocaml_struct = make_mystruct(cr, &OCaml::unit());
+/// let ocaml_struct_root = make_mystruct(cr, &OCaml::unit());
+/// let ocaml_struct = cr.get(&ocaml_struct_root);
 /// let my_struct = ocaml_unpack_record! {
 ///     //  value    => RustConstructor { field: OCamlType, ... }
 ///     ocaml_struct => MyStruct {
@@ -455,17 +359,15 @@ macro_rules! ocaml_unpack_record {
 macro_rules! ocaml_alloc_tagged_block {
     ($cr:ident, $tag:expr, $($field:ident : $ocaml_typ:ty),+ $(,)?) => {
         unsafe {
-            $crate::ocaml_frame!($cr, (block), {
-                let mut current = 0;
-                let field_count = $crate::count_fields!($($field)*);
-                let block: $crate::OCamlRef<()> = block.keep_raw($crate::internal::caml_alloc(field_count, $tag));
-                $(
-                    let $field: $crate::OCaml<$ocaml_typ> = $crate::to_ocaml!($cr, $field);
-                    $crate::internal::store_field(block.get_raw(), current, $field.raw());
-                    current += 1;
-                )+
-                $crate::OCaml::new($cr, block.get_raw())
-            })
+            let mut current = 0;
+            let field_count = $crate::count_fields!($($field)*);
+            let block: $crate::BoxRoot<()> = $crate::BoxRoot::new($crate::OCaml::new($cr, $crate::internal::caml_alloc(field_count, $tag)));
+            $(
+                let $field: $crate::OCaml<$ocaml_typ> = $field.to_ocaml($cr);
+                $crate::internal::store_field(block.get_raw(), current, $field.raw());
+                current += 1;
+            )+
+            $crate::OCaml::new($cr, block.get_raw())
         }
     };
 }
@@ -519,18 +421,16 @@ macro_rules! ocaml_alloc_record {
         $($field:ident : $ocaml_typ:ty $(=> $conv_expr:expr)?),+ $(,)?
     }) => {
         unsafe {
-            $crate::ocaml_frame!($cr, (record), {
-                let mut current = 0;
-                let field_count = $crate::count_fields!($($field)*);
-                let record: $crate::OCamlRef<()> = record.keep_raw($crate::internal::caml_alloc(field_count, 0));
-                $(
-                    let $field = &$crate::prepare_field_for_mapping!($self.$field $(=> $conv_expr)?);
-                    let $field: $crate::OCaml<$ocaml_typ> = $crate::to_ocaml!($cr, $field);
-                    $crate::internal::store_field(record.get_raw(), current, $field.raw());
-                    current += 1;
-                )+
-                $crate::OCaml::new($cr, record.get_raw())
-            })
+            let mut current = 0;
+            let field_count = $crate::count_fields!($($field)*);
+            let record: $crate::BoxRoot<()> = $crate::BoxRoot::new($crate::OCaml::new($cr, $crate::internal::caml_alloc(field_count, 0)));
+            $(
+                let $field = &$crate::prepare_field_for_mapping!($self.$field $(=> $conv_expr)?);
+                let $field: $crate::OCaml<$ocaml_typ> = $field.to_ocaml($cr);
+                $crate::internal::store_field(record.get_raw(), current, $field.raw());
+                current += 1;
+            )+
+            $crate::OCaml::new($cr, record.get_raw())
         }
     };
 }
@@ -779,7 +679,8 @@ macro_rules! impl_from_ocaml_variant {
 /// // NOTE: What is important is the order of the tags, not their names.
 ///
 /// # fn unpack_variant_example(cr: &mut OCamlRuntime) {
-/// let ocaml_variant = make_ocaml_movement(cr, &OCaml::unit());
+/// let ocaml_variant_root = make_ocaml_movement(cr, &OCaml::unit());
+/// let ocaml_variant = cr.get(&ocaml_variant_root);
 /// let result = ocaml_unpack_variant! {
 ///     ocaml_variant => {
 ///         // Alternative: StepLeft  => Movement::StepLeft
@@ -1041,7 +942,8 @@ macro_rules! impl_from_ocaml_polymorphic_variant {
 /// //      ]
 ///
 /// # fn unpack_polymorphic_variant_example(cr: &mut OCamlRuntime) {
-/// let ocaml_polymorphic_variant = make_ocaml_polymorphic_movement(cr, &OCaml::unit());
+/// let ocaml_polymorphic_variant_root = make_ocaml_polymorphic_movement(cr, &OCaml::unit());
+/// let ocaml_polymorphic_variant = cr.get(&ocaml_polymorphic_variant_root);
 /// let result = ocaml_unpack_polymorphic_variant! {
 ///     ocaml_polymorphic_variant => {
 ///         StepLeft  => Movement::StepLeft,
@@ -1368,21 +1270,22 @@ macro_rules! default_to_unit {
 #[macro_export]
 macro_rules! expand_rooted_args_init {
     // No more args
-    ((), ) => ();
+    () => ();
 
     // Nothing is done for unboxed floats
-    ((), $arg:ident : f64) => ();
+    ($arg:ident : f64) => ();
 
-    (($($roots:ident)*), $arg:ident : f64, $($args:tt)*) =>
-        ($crate::expand_rooted_args_init!(($($roots)*), $($args)*));
+    ($arg:ident : f64, $($args:tt)*) =>
+        ($crate::expand_rooted_args_init!($($args)*));
 
     // Other values are wrapped in `OCamlRef<T>` as given the same lifetime as the OCaml runtime handle borrow.
-    (($root:ident), $arg:ident : $typ:ty) =>
-        (let $arg : $typ = unsafe { $root.keep_raw($arg) };);
+    ($arg:ident : $typ:ty) => {
+        let $arg : $typ = unsafe { &$crate::BoxRoot::from_raw($arg) };
+    };
 
-    (($root:ident $($roots:ident)*), $arg:ident : $typ:ty, $($args:tt)*) => {
-        let $arg : $typ = unsafe { $root.keep_raw($arg) };
-        $crate::expand_rooted_args_init!(($($roots)*), $($args)*)
+    ($arg:ident : $typ:ty, $($args:tt)*) => {
+        let $arg : $typ = unsafe { &$crate::BoxRoot::from_raw($arg) };
+        $crate::expand_rooted_args_init!($($args)*)
     };
 }
 
@@ -1391,12 +1294,9 @@ macro_rules! expand_rooted_args_init {
 macro_rules! expand_exported_function {
     // Final expansions, with all argument types converted
 
-    // If there are no roots, don't open a frame
-
     {
         @name $name:ident
         @cr $cr:ident
-        @roots { }
         @final_args { $($arg:ident : $typ:ty,)+ }
         @proc_args { $(,)? }
         @return { $($rtyp:tt)* }
@@ -1406,35 +1306,11 @@ macro_rules! expand_exported_function {
         #[no_mangle]
         pub extern "C" fn $name( $($arg: $typ),* ) -> $crate::expand_exported_function_return!($($rtyp)*) {
             let $cr = unsafe { &mut $crate::OCamlRuntime::recover_handle() };
+            $crate::expand_rooted_args_init!($($original_args)*);
             $crate::expand_exported_function_body!(
                 @body $body
                 @return $($rtyp)*
             )
-        }
-    };
-
-    // If there are roots, open a new frame and root the arguments
-
-    {
-        @name $name:ident
-        @cr $cr:ident
-        @roots { $($roots:ident)* }
-        @final_args { $($arg:ident : $typ:ty,)+ }
-        @proc_args { $(,)? }
-        @return { $($rtyp:tt)* }
-        @body $body:block
-        @original_args $($original_args:tt)*
-    } => {
-        #[no_mangle]
-        pub extern "C" fn $name( $($arg: $typ),* ) -> $crate::expand_exported_function_return!($($rtyp)*) {
-            let $cr = unsafe { &mut $crate::OCamlRuntime::recover_handle() };
-            $crate::ocaml_frame!($cr, ($($roots),*), {
-                $crate::expand_rooted_args_init!(($($roots)*), $($original_args)*);
-                $crate::expand_exported_function_body!(
-                    @body $body
-                    @return $($rtyp)*
-                )
-            })
         }
     };
 
@@ -1445,7 +1321,6 @@ macro_rules! expand_exported_function {
     {
         @name $name:ident
         @cr $cr:ident
-        @roots { $($roots:ident)* }
         @final_args { $($final_args:tt)* }
         @proc_args { $next_arg:ident : f64, $($proc_args:tt)* }
         @return { $($rtyp:tt)* }
@@ -1455,7 +1330,6 @@ macro_rules! expand_exported_function {
         $crate::expand_exported_function!{
             @name $name
             @cr $cr
-            @roots { $($roots)* }
             @final_args { $($final_args)* $next_arg : f64, }
             @proc_args { $($proc_args)* }
             @return { $($rtyp)* }
@@ -1469,7 +1343,6 @@ macro_rules! expand_exported_function {
     {
         @name $name:ident
         @cr $cr:ident
-        @roots { $($roots:ident)* }
         @final_args { $($final_args:tt)* }
         @proc_args { $next_arg:ident : $typ:ty, $($proc_args:tt)* }
         @return { $($rtyp:tt)* }
@@ -1479,7 +1352,6 @@ macro_rules! expand_exported_function {
         $crate::expand_exported_function!{
             @name $name
             @cr $cr
-            @roots { $($roots)* root }
             @final_args { $($final_args)* $next_arg : $crate::RawOCaml, }
             @proc_args { $($proc_args)* }
             @return { $($rtyp)* }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -100,49 +100,9 @@ pub fn alloc_some<'a, 'b, A>(
     }
 }
 
-pub fn alloc_tuple<'a, 'b, F, S>(
-    cr: &'a mut OCamlRuntime,
-    fst: OCamlRef<'b, F>,
-    snd: OCamlRef<'b, S>,
-) -> OCaml<'a, (F, S)> {
-    unsafe {
-        let ocaml_tuple = caml_alloc_tuple(2);
-        store_field(ocaml_tuple, 0, fst.get_raw());
-        store_field(ocaml_tuple, 1, snd.get_raw());
-        OCaml::new(cr, ocaml_tuple)
-    }
-}
-
-pub fn alloc_tuple_3<'a, 'b, F, S, T3>(
-    cr: &'a mut OCamlRuntime,
-    fst: OCamlRef<'b, F>,
-    snd: OCamlRef<'b, S>,
-    elt3: OCamlRef<'b, T3>,
-) -> OCaml<'a, (F, S, T3)> {
-    unsafe {
-        let ocaml_tuple = caml_alloc_tuple(3);
-        store_field(ocaml_tuple, 0, fst.get_raw());
-        store_field(ocaml_tuple, 1, snd.get_raw());
-        store_field(ocaml_tuple, 2, elt3.get_raw());
-        OCaml::new(cr, ocaml_tuple)
-    }
-}
-
-pub fn alloc_tuple_4<'a, 'b, F, S, T3, T4>(
-    cr: &'a mut OCamlRuntime,
-    fst: OCamlRef<'b, F>,
-    snd: OCamlRef<'b, S>,
-    elt3: OCamlRef<'b, T3>,
-    elt4: OCamlRef<'b, T4>,
-) -> OCaml<'a, (F, S, T3, T4)> {
-    unsafe {
-        let ocaml_tuple = caml_alloc_tuple(4);
-        store_field(ocaml_tuple, 0, fst.get_raw());
-        store_field(ocaml_tuple, 1, snd.get_raw());
-        store_field(ocaml_tuple, 2, elt3.get_raw());
-        store_field(ocaml_tuple, 3, elt4.get_raw());
-        OCaml::new(cr, ocaml_tuple)
-    }
+pub unsafe fn alloc_tuple<T>(cr: &mut OCamlRuntime, size: usize) -> OCaml<T> {
+    let ocaml_tuple = caml_alloc_tuple(size);
+    OCaml::new(cr, ocaml_tuple)
 }
 
 pub fn alloc_cons<'a, 'b, A>(

--- a/src/mlvalues.rs
+++ b/src/mlvalues.rs
@@ -1,6 +1,9 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+#[cfg(doc)]
+use crate::*;
+
 use core::marker::PhantomData;
 pub use ocaml_sys::{
     extract_exception, field as field_val, is_block, is_exception_result, is_long, string_val,
@@ -10,28 +13,28 @@ pub use ocaml_sys::{
 
 pub mod tag;
 
-/// `OCaml<OCamlList<T>>` is a reference to an OCaml `list` containing
+/// [`OCaml`]`<OCamlList<T>>` is a reference to an OCaml `list` containing
 /// values of type `T`.
 pub struct OCamlList<A> {
     _marker: PhantomData<A>,
 }
 
-/// `OCaml<OCamlBytes>` is a reference to an OCaml `bytes` value.
+/// [`OCaml`]`<OCamlBytes>` is a reference to an OCaml `bytes` value.
 ///
 /// # Note
 ///
-/// Unlike with `OCaml<String>`, there is no validation being performed when converting this
+/// Unlike with [`OCaml`]`<String>`, there is no validation being performed when converting this
 /// value into `String`.
 pub struct OCamlBytes {}
 
-/// `OCaml<OCamlInt>` is an OCaml integer (tagged and unboxed) value.
+/// [`OCaml`]`<OCamlInt>` is an OCaml integer (tagged and unboxed) value.
 pub type OCamlInt = Intnat;
 
-/// `OCaml<OCamlInt32>` is a reference to an OCaml `Int32.t` (boxed `int32`) value.
+/// [`OCaml`]`<OCamlInt32>` is a reference to an OCaml `Int32.t` (boxed `int32`) value.
 pub struct OCamlInt32 {}
 
-/// `OCaml<OCamlInt64>` is a reference to an OCaml `Int64.t` (boxed `int64`) value.
+/// [`OCaml`]`<OCamlInt64>` is a reference to an OCaml `Int64.t` (boxed `int64`) value.
 pub struct OCamlInt64 {}
 
-/// `OCaml<OCamlFloat>` is a reference to an OCaml `float` (boxed `float`) value.
+/// [`OCaml`]`<OCamlFloat>` is a reference to an OCaml `float` (boxed `float`) value.
 pub struct OCamlFloat {}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,18 +8,27 @@ use std::{marker::PhantomData, sync::Once};
 use crate::{memory::OCamlRef, value::OCaml};
 
 /// OCaml runtime handle.
+///
+/// Should be initialized once at the beginning of the program
+/// and the obtained handle passed around.
+///
+/// Once the handle is dropped, the OCaml runtime will be shutdown.
 pub struct OCamlRuntime {
     _private: (),
 }
 
 impl OCamlRuntime {
     /// Initializes the OCaml runtime and returns an OCaml runtime handle.
+    ///
+    /// Once the handle is dropped, the OCaml runtime will be shutdown.
     pub fn init() -> Self {
         Self::init_persistent();
         Self { _private: () }
     }
 
     /// Initializes the OCaml runtime.
+    ///
+    /// After the first invocation, this method does nothing.
     pub fn init_persistent() {
         static INIT: Once = Once::new();
 
@@ -95,7 +104,7 @@ impl Drop for OCamlBlockingSection {
     }
 }
 
-// For initializing from an OCaml-drived program
+// For initializing from an OCaml-driven program
 
 #[no_mangle]
 extern "C" fn ocaml_interop_setup(_unit: crate::RawOCaml) -> crate::RawOCaml {

--- a/src/value.rs
+++ b/src/value.rs
@@ -318,60 +318,6 @@ impl<'a, A, Err> OCaml<'a, Result<A, Err>> {
     }
 }
 
-impl<'a, A, B> OCaml<'a, (A, B)> {
-    pub fn to_tuple(&self) -> (OCaml<'a, A>, OCaml<'a, B>) {
-        (self.fst(), self.snd())
-    }
-
-    pub fn fst(&self) -> OCaml<'a, A> {
-        unsafe { self.field(0) }
-    }
-
-    pub fn snd(&self) -> OCaml<'a, B> {
-        unsafe { self.field(1) }
-    }
-}
-
-impl<'a, A, B, C> OCaml<'a, (A, B, C)> {
-    pub fn to_tuple(&self) -> (OCaml<'a, A>, OCaml<'a, B>, OCaml<'a, C>) {
-        (self.fst(), self.snd(), self.tuple_3())
-    }
-
-    pub fn fst(&self) -> OCaml<'a, A> {
-        unsafe { self.field(0) }
-    }
-
-    pub fn snd(&self) -> OCaml<'a, B> {
-        unsafe { self.field(1) }
-    }
-
-    pub fn tuple_3(&self) -> OCaml<'a, C> {
-        unsafe { self.field(2) }
-    }
-}
-
-impl<'a, A, B, C, D> OCaml<'a, (A, B, C, D)> {
-    pub fn to_tuple(&self) -> (OCaml<'a, A>, OCaml<'a, B>, OCaml<'a, C>, OCaml<'a, D>) {
-        (self.fst(), self.snd(), self.tuple_3(), self.tuple_4())
-    }
-
-    pub fn fst(&self) -> OCaml<'a, A> {
-        unsafe { self.field(0) }
-    }
-
-    pub fn snd(&self) -> OCaml<'a, B> {
-        unsafe { self.field(1) }
-    }
-
-    pub fn tuple_3(&self) -> OCaml<'a, C> {
-        unsafe { self.field(2) }
-    }
-
-    pub fn tuple_4(&self) -> OCaml<'a, D> {
-        unsafe { self.field(3) }
-    }
-}
-
 impl<'a, A> OCaml<'a, OCamlList<A>> {
     /// Returns an OCaml nil (empty list) value.
     pub fn nil() -> Self {
@@ -413,3 +359,75 @@ impl<'a, A> OCaml<'a, OCamlList<A>> {
         }
     }
 }
+
+// Tuples
+
+macro_rules! impl_tuple {
+    ($($n:tt: $accessor:ident -> $t:ident),+) => {
+        impl<'a, $($t),+> OCaml<'a, ($($t),+)>
+        {
+            pub fn to_tuple(&self) -> ($(OCaml<'a, $t>),+) {
+                ($(self.$accessor()),+)
+            }
+
+            $(
+                pub fn $accessor(&self) -> OCaml<'a, $t> {
+                    unsafe { self.field($n) }
+                }
+            )+
+        }
+    };
+}
+
+impl_tuple!(
+    0: fst -> A,
+    1: snd -> B);
+impl_tuple!(
+    0: fst -> A,
+    1: snd -> B,
+    2: tuple_3 -> C);
+impl_tuple!(
+    0: fst -> A,
+    1: snd -> B,
+    2: tuple_3 -> C,
+    3: tuple_4 -> D);
+impl_tuple!(
+    0: fst -> A,
+    1: snd -> B,
+    2: tuple_3 -> C,
+    3: tuple_4 -> D,
+    4: tuple_5 -> E);
+impl_tuple!(
+    0: fst -> A,
+    1: snd -> B,
+    2: tuple_3 -> C,
+    3: tuple_4 -> D,
+    4: tuple_5 -> E,
+    5: tuple_6 -> F);
+impl_tuple!(
+    0: fst -> A,
+    1: snd -> B,
+    2: tuple_3 -> C,
+    3: tuple_4 -> D,
+    4: tuple_5 -> E,
+    5: tuple_6 -> F,
+    6: tuple_7 -> G);
+impl_tuple!(
+    0: fst -> A,
+    1: snd -> B,
+    2: tuple_3 -> C,
+    3: tuple_4 -> D,
+    4: tuple_5 -> E,
+    5: tuple_6 -> F,
+    6: tuple_7 -> G,
+    7: tuple_8 -> H);
+impl_tuple!(
+    0: fst -> A,
+    1: snd -> B,
+    2: tuple_3 -> C,
+    3: tuple_4 -> D,
+    4: tuple_5 -> E,
+    5: tuple_6 -> F,
+    6: tuple_7 -> G,
+    7: tuple_8 -> H,
+    8: tuple_9 -> I);

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 use crate::{
-    error::OCamlFixnumConversionError, memory::OCamlCell, mlvalues::*, FromOCaml, OCamlRef,
-    OCamlRuntime,
+    boxroot::BoxRoot, error::OCamlFixnumConversionError, memory::OCamlCell, mlvalues::*, FromOCaml,
+    OCamlRef, OCamlRuntime,
 };
 use core::{marker::PhantomData, ops::Deref, slice, str};
 use ocaml_sys::{caml_string_length, int_val, val_int};
@@ -89,6 +89,10 @@ impl<'a, T> OCaml<'a, T> {
     {
         let ptr = &self.raw as *const RawOCaml;
         unsafe { OCamlCell::create_ref(ptr) }
+    }
+
+    pub fn root(self) -> BoxRoot<T> {
+        BoxRoot::new(self)
     }
 
     /// Gets the raw representation for this value reference (pointer or int).

--- a/testing/ocaml-caller/ocaml_rust_caller.ml
+++ b/testing/ocaml-caller/ocaml_rust_caller.ml
@@ -20,6 +20,11 @@ type movement_polymorphic =
   | `UnkownBlock of int ]
 
 module Rust = struct
+  (* Must be called first *)
+  external tests_setup : unit -> unit = "ocaml_interop_setup"
+
+  external tests_teardown : unit -> unit = "ocaml_interop_teardown"
+
   external twice : int -> int = "rust_twice"
 
   external twice_boxed_i64 : int64 -> int64 = "rust_twice_boxed_i64"
@@ -170,6 +175,7 @@ let test_regular_section () =
   Alcotest.check testable "Acquires the runtime lock" () ()
 
 let () =
+  Rust.tests_setup ();
   let open Alcotest in
   run "Tests"
     [
@@ -192,4 +198,5 @@ let () =
           test_case "Rust.string_of_polymorphic_movement" `Quick
             test_interpret_polymorphic_movement;
         ] );
-    ]
+    ];
+  Rust.tests_teardown ()

--- a/testing/ocaml-caller/rust/src/lib.rs
+++ b/testing/ocaml-caller/rust/src/lib.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 use ocaml_interop::{
-    ocaml_export, ocaml_unpack_polymorphic_variant, ocaml_unpack_variant, to_ocaml,
-    OCaml, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, OCamlRef,
-    ToOCaml,
+    ocaml_export, ocaml_unpack_polymorphic_variant, ocaml_unpack_variant, OCaml, OCamlBytes,
+    OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, OCamlRef, ToOCaml,
 };
 use std::{thread, time};
 
@@ -90,13 +89,13 @@ ocaml_export! {
     fn rust_make_ok(cr, value: OCamlRef<OCamlInt>) -> OCaml<Result<OCamlInt, String>> {
         let value: i64 = value.to_rust(cr);
         let ok_value: Result<i64, String> = Ok(value);
-        to_ocaml!(cr, ok_value)
+        ok_value.to_ocaml(cr)
     }
 
     fn rust_make_error(cr, value: OCamlRef<String>) -> OCaml<Result<OCamlInt, String>> {
         let value: String = value.to_rust(cr);
         let error_value: Result<i64, String> = Err(value);
-        to_ocaml!(cr, error_value)
+        error_value.to_ocaml(cr)
     }
 
     fn rust_sleep_releasing(cr, millis: OCamlRef<OCamlInt>) {
@@ -126,7 +125,7 @@ ocaml_export! {
             Ok(Movement::RotateLeft) => "RotateLeft".to_owned(),
             Ok(Movement::RotateRight) => "RotateRight".to_owned(),
         };
-        to_ocaml!(cr, s)
+        s.to_ocaml(cr)
     }
 
     fn rust_string_of_polymorphic_movement(cr, polymorphic_movement: OCamlRef<PolymorphicMovement>) -> OCaml<String> {
@@ -144,6 +143,6 @@ ocaml_export! {
             Ok(PolymorphicMovement::RotateLeft) => "`RotateLeft".to_owned(),
             Ok(PolymorphicMovement::RotateRight) => "`RotateRight".to_owned(),
         };
-        to_ocaml!(cr, s)
+        s.to_ocaml(cr)
     }
 }

--- a/testing/rust-caller/src/lib.rs
+++ b/testing/rust-caller/src/lib.rs
@@ -3,7 +3,7 @@
 
 extern crate ocaml_interop;
 
-use ocaml_interop::{ocaml_frame, to_ocaml, OCaml, OCamlBytes, OCamlRuntime, ToOCaml};
+use ocaml_interop::{OCaml, OCamlBytes, OCamlRuntime, ToOCaml};
 
 mod ocaml {
     use ocaml_interop::{
@@ -62,81 +62,67 @@ mod ocaml {
 }
 
 pub fn increment_bytes(cr: &mut OCamlRuntime, bytes: &str, first_n: usize) -> String {
-    ocaml_frame!(cr, (bytes_root), {
-        let bytes = to_ocaml!(cr, bytes, bytes_root);
-        let first_n = unsafe { OCaml::of_i64_unchecked(first_n as i64) };
-        let result = ocaml::increment_bytes(cr, bytes, &first_n);
-        result.to_rust()
-    })
+    let bytes = bytes.to_boxroot(cr);
+    let first_n = unsafe { OCaml::of_i64_unchecked(first_n as i64) };
+    let result = ocaml::increment_bytes(cr, &bytes, &first_n);
+    result.to_rust(cr)
 }
 
 pub fn increment_ints_list(cr: &mut OCamlRuntime, ints: &Vec<i64>) -> Vec<i64> {
-    ocaml_frame!(cr, (root), {
-        let ints = to_ocaml!(cr, ints, root);
-        let result = ocaml::increment_ints_list(cr, ints);
-        result.to_rust()
-    })
+    let ints = ints.to_boxroot(cr);
+    let result = ocaml::increment_ints_list(cr, &ints);
+    result.to_rust(cr)
 }
 
 pub fn twice(cr: &mut OCamlRuntime, num: i64) -> i64 {
     let num = unsafe { OCaml::of_i64_unchecked(num) };
     let result = ocaml::twice(cr, &num);
-    result.to_rust()
+    result.to_rust(cr)
 }
 
 pub fn make_tuple(cr: &mut OCamlRuntime, fst: String, snd: i64) -> (String, i64) {
-    ocaml_frame!(cr, (str_root), {
-        let num = unsafe { OCaml::of_i64_unchecked(snd) };
-        let str = to_ocaml!(cr, fst, str_root);
-        let result = ocaml::make_tuple(cr, str, &num);
-        result.to_rust()
-    })
+    let num = unsafe { OCaml::of_i64_unchecked(snd) };
+    let str = fst.to_boxroot(cr);
+    let result = ocaml::make_tuple(cr, &str, &num);
+    result.to_rust(cr)
 }
 
 pub fn make_some(cr: &mut OCamlRuntime, value: String) -> Option<String> {
-    ocaml_frame!(cr, (root), {
-        let str = to_ocaml!(cr, value, root);
-        let result = ocaml::make_some(cr, str);
-        result.to_rust()
-    })
+    let str = value.to_boxroot(cr);
+    let result = ocaml::make_some(cr, &str);
+    result.to_rust(cr)
 }
 
 pub fn make_ok(cr: &mut OCamlRuntime, value: i64) -> Result<i64, String> {
     let value = unsafe { OCaml::of_i64_unchecked(value) };
     let result = ocaml::make_ok(cr, &value);
-    result.to_rust()
+    result.to_rust(cr)
 }
 
 pub fn make_error(cr: &mut OCamlRuntime, value: String) -> Result<i64, String> {
-    ocaml_frame!(cr, (root), {
-        let result = to_ocaml!(cr, value, root);
-        let result = ocaml::make_error(cr, result);
-        result.to_rust()
-    })
+    let result = value.to_boxroot(cr);
+    let result = ocaml::make_error(cr, &result);
+    result.to_rust(cr)
 }
 
 pub fn verify_record_test(cr: &mut OCamlRuntime, record: ocaml::TestRecord) -> String {
-    ocaml_frame!(cr, (root), {
-        let ocaml_record = to_ocaml!(cr, record, root);
-        let result = ocaml::stringify_record(cr, ocaml_record);
-        result.to_rust()
-    })
+    let ocaml_record = record.to_boxroot(cr);
+    let result = ocaml::stringify_record(cr, &ocaml_record);
+    result.to_rust(cr)
 }
 
 pub fn verify_variant_test(cr: &mut OCamlRuntime, variant: ocaml::Movement) -> String {
-    ocaml_frame!(cr, (root), {
-        let ocaml_variant = to_ocaml!(cr, variant, root);
-        let result = ocaml::stringify_variant(cr, ocaml_variant);
-        result.to_rust()
-    })
+    let ocaml_variant = variant.to_boxroot(cr);
+    let result = ocaml::stringify_variant(cr, &ocaml_variant);
+    result.to_rust(cr)
 }
 
 pub fn allocate_alot(cr: &mut OCamlRuntime) -> bool {
     let vec = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     for _n in 1..50000 {
-        let _x: OCaml<OCamlBytes> = to_ocaml!(cr, vec);
-        let _y: OCaml<OCamlBytes> = to_ocaml!(cr, vec);
-        let _z: OCaml<OCamlBytes> = to_ocaml!(cr, vec);
+        let _x: OCaml<OCamlBytes> = vec.to_ocaml(cr);
+        let _y: OCaml<OCamlBytes> = vec.to_ocaml(cr);
+        let _z: OCaml<OCamlBytes> = vec.to_ocaml(cr);
         ()
     }
     true
@@ -255,7 +241,6 @@ fn test_variant_conversion() {
     );
 }
 
-
 #[test]
 #[serial]
 fn test_exception_handling_with_message() {
@@ -263,13 +248,14 @@ fn test_exception_handling_with_message() {
     let result = std::panic::catch_unwind(move || {
         let mut cr = unsafe { OCamlRuntime::recover_handle() };
         let mcr = &mut cr;
-        ocaml_frame!(mcr, (message_root), {
-            let message = to_ocaml!(mcr, "my-error-message", message_root);
-            ocaml::raises_message_exception(mcr, message);
-        });
+        let message = "my-error-message".to_boxroot(mcr);
+        ocaml::raises_message_exception(mcr, &message);
     });
     assert_eq!(
-        result.err().and_then(|err| Some(err.downcast_ref::<String>().unwrap().clone())).unwrap(),
+        result
+            .err()
+            .and_then(|err| Some(err.downcast_ref::<String>().unwrap().clone()))
+            .unwrap(),
         "OCaml exception, message: Some(\"my-error-message\")"
     );
 }
@@ -283,7 +269,10 @@ fn test_exception_handling_without_message() {
         ocaml::raises_nonmessage_exception(cr, &OCaml::unit());
     });
     assert_eq!(
-        result.err().and_then(|err| Some(err.downcast_ref::<String>().unwrap().clone())).unwrap(),
+        result
+            .err()
+            .and_then(|err| Some(err.downcast_ref::<String>().unwrap().clone()))
+            .unwrap(),
         "OCaml exception, message: None"
     );
 }
@@ -297,7 +286,10 @@ fn test_exception_handling_nonblock_exception() {
         ocaml::raises_nonblock_exception(cr, &OCaml::unit());
     });
     assert_eq!(
-        result.err().and_then(|err| Some(err.downcast_ref::<String>().unwrap().clone())).unwrap(),
+        result
+            .err()
+            .and_then(|err| Some(err.downcast_ref::<String>().unwrap().clone()))
+            .unwrap(),
         "OCaml exception, message: None"
     );
 }


### PR DESCRIPTION
Switching to [ocaml-boxroot](https://gitlab.com/ocaml-rust/ocaml-boxroot) for roots management.

### TODO

- [x] Implement (and use) `BoxRoot`
- [x] Remove `to_ocaml!`, `ocaml_frame!`, etc (no longer needed macros)
- [x] Update tests
- [x] Finish updating documentation (remove outdated stuff, explain OCaml/Boxroot/OCamlRef, etc)
- [x] Update CHANGELOG